### PR TITLE
Port KAMISHIBAI to .NET MAUI.

### DIFF
--- a/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
@@ -1,0 +1,176 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+    public class ApplicationServiceFixture
+    {
+        internal static Mock<ApplicationService.IApplication> ApplicationMock = new Mock<ApplicationService.IApplication>();
+        static ApplicationServiceFixture()
+        {
+            ApplicationService.Initialize(new ApplicationMock());
+            ApplicationService.Current = new Mock<ApplicationService.IApplication>().Object;
+            ApplicationService.Current = ApplicationMock.Object;
+        }
+
+        [Fact]
+        public void SetMainPage()
+        {
+            var behaviorInjector = new Mock<IBehaviorInjector>();
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+
+            behaviorInjector.Setup(m => m.Inject(contentPageMock))
+                .Callback(() => eventRecorder.Record(behaviorInjector));
+
+            ApplicationService.BehaviorInjector = behaviorInjector.Object;
+
+            ApplicationService.SetMainPage(contentPageMock);
+
+            ApplicationMock.VerifySet(m => m.MainPage = contentPageMock);
+
+            Assert.Equal(3, eventRecorder.Count);
+
+            // BehaviorInjector
+            Assert.NotNull(eventRecorder[0]);
+            Assert.Equal(behaviorInjector, eventRecorder[0].Sender);
+
+            // OnInitialize
+            Assert.NotNull(eventRecorder[1]);
+            Assert.Equal(contentPageMock, eventRecorder[1].Sender);
+            Assert.Equal("OnInitialize", eventRecorder[1].CallerMemberName);
+
+            // OnLoaded
+            Assert.NotNull(eventRecorder[2]);
+            Assert.Equal(contentPageMock, eventRecorder[2].Sender);
+            Assert.Equal("OnLoaded", eventRecorder[2].CallerMemberName);
+        }
+
+        [Fact]
+        public void SetMainPage_WithParameter()
+        {
+            var behaviorInjector = new Mock<IBehaviorInjector>();
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+
+            behaviorInjector.Setup(m => m.Inject(contentPageMock))
+                .Callback(() => eventRecorder.Record(behaviorInjector));
+
+            ApplicationService.BehaviorInjector = behaviorInjector.Object;
+
+            var parameter = new object();
+
+            ApplicationService.SetMainPage(contentPageMock, parameter);
+
+            ApplicationMock.VerifySet(m => m.MainPage = contentPageMock);
+
+            Assert.Equal(3, eventRecorder.Count);
+
+            // BehaviorInjector
+            Assert.NotNull(eventRecorder[0]);
+            Assert.Equal(behaviorInjector, eventRecorder[0].Sender);
+
+            // OnInitialize
+            Assert.NotNull(eventRecorder[1]);
+            Assert.Equal(contentPageMock, eventRecorder[1].Sender);
+            Assert.Equal("OnInitialize", eventRecorder[1].CallerMemberName);
+            Assert.Equal(parameter, eventRecorder[1].Parameter);
+
+            // OnLoaded
+            Assert.NotNull(eventRecorder[2]);
+            Assert.Equal(contentPageMock, eventRecorder[2].Sender);
+            Assert.Equal("OnLoaded", eventRecorder[2].CallerMemberName);
+        }
+
+        [Fact]
+        public void PopModal()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecorder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecorder) { Title = "contentPageMock2" };
+            var contentPageMock3 = new ContentPageMock(eventRecorder) { Title = "contentPageMock3" };
+
+            //Mocks.ApplicationMock.MainPage = contentPageMock1;
+            contentPageMock1.Navigation.PushModalAsync(contentPageMock2);
+            contentPageMock2.Navigation.PushModalAsync(contentPageMock3);
+
+            ApplicationMock.SetupGet(m => m.MainPage).Returns(contentPageMock1);
+
+            ApplicationMock.Raise(m => m.ModalPopped += null, new ModalPoppedEventArgs(contentPageMock3));
+
+            Assert.Equal(2, eventRecorder.Count);
+
+            // OnLoaded
+            Assert.NotNull(eventRecorder[0]);
+            Assert.Equal(contentPageMock2, eventRecorder[0].Sender);
+            Assert.Equal("OnLoaded", eventRecorder[0].CallerMemberName);
+
+            // OnClosed
+            Assert.NotNull(eventRecorder[1]);
+            Assert.Equal(contentPageMock3, eventRecorder[1].Sender);
+            Assert.Equal("OnClosed", eventRecorder[1].CallerMemberName);
+        }
+
+        [Fact]
+        public void ApplicationAdapter_MainPage()
+        {
+            var mock = new ApplicationMock();
+            var adapter = (ApplicationService.IApplication)new ApplicationService.ApplicationAdapter(mock);
+            var page = new ContentPage();
+            adapter.MainPage = page;
+            
+            Assert.Equal(page, mock.MainPage);
+            Assert.Equal(page, adapter.MainPage);
+        }
+
+        [Fact]
+        public void ApplicationAdapter_ModalPopped()
+        {
+            var mock = new ApplicationMock();
+            var adapter = (ApplicationService.IApplication)new ApplicationService.ApplicationAdapter(mock);
+            var page1 = new ContentPage();
+            adapter.MainPage = page1;
+            
+            var page2 = new ContentPage();
+            page1.Navigation.PushModalAsync(page2);
+
+            bool popped = false;
+            adapter.ModalPopped += (sender, args) =>
+            {
+                popped = true;
+                Assert.NotNull(sender);
+                Assert.NotNull(args);
+                Assert.Equal(page2, args.Modal);
+            };
+
+            page2.Navigation.PopModalAsync();
+            
+            Assert.True(popped);
+        }
+
+        [Fact]
+        public void ApplicationAdapter_ModalPopped_WhenNotListened()
+        {
+            var mock = new ApplicationMock();
+            var adapter = (ApplicationService.IApplication)new ApplicationService.ApplicationAdapter(mock);
+            var page1 = new ContentPage();
+            adapter.MainPage = page1;
+
+            var page2 = new ContentPage();
+            page1.Navigation.PushModalAsync(page2);
+
+            page2.Navigation.PopModalAsync();
+
+            Assert.True(true);
+        }
+
+        [Fact]
+        public void ApplicationAdapter_WhenApplicationIsNull()
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            new ApplicationService.ApplicationAdapter(null);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/ApplicationServiceFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-    public class ApplicationServiceFixture
+    public class ApplicationServiceFixture : TestFixture
     {
         internal static Mock<ApplicationService.IApplication> ApplicationMock = new Mock<ApplicationService.IApplication>();
         static ApplicationServiceFixture()

--- a/MAUI/Source/Kamishibai.Maui.Tests/BehaviorBaseFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/BehaviorBaseFixture.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+    public class BehaviorBaseFixture
+    {
+        [Fact]
+        public void FromAttachToDettach()
+        {
+            var page = new ContentPage();
+            var contextObject = new object();
+            page.BindingContext = contextObject;
+
+            var behavior = new BehaviorMock();
+            page.Behaviors.Add(behavior);
+
+            Assert.NotNull(behavior.BindingContext);
+            Assert.Equal(contextObject, behavior.BindingContext);
+
+            page.Behaviors.Clear();
+            Assert.Null(behavior.BindingContext);
+        }
+
+        [Fact]
+        public void ParentBindingContextChanged()
+        {
+            var page = new ContentPage();
+            var contextObject = new object();
+
+            var behavior = new BehaviorMock();
+            page.Behaviors.Add(behavior);
+
+            Assert.Null(behavior.BindingContext);
+            page.BindingContext = contextObject;
+
+            Assert.NotNull(behavior.BindingContext);
+            Assert.Equal(contextObject, behavior.BindingContext);
+
+            page.BindingContext = null;
+            Assert.Null(behavior.BindingContext);
+
+            page.Behaviors.Clear();
+
+            // Chech removed event handler
+            page.BindingContext = new object();
+            Assert.Null(behavior.BindingContext);
+        }
+
+        [Fact]
+        public void HasOriginalBindingContext()
+        {
+            var page = new ContentPage();
+            var contextObject = new object();
+            page.BindingContext = contextObject;
+
+            var behavior = new BehaviorMock { BindingContext = new object() };
+            page.Behaviors.Add(behavior);
+
+            Assert.NotNull(behavior.BindingContext);
+            Assert.NotEqual(contextObject, behavior.BindingContext);
+
+            page.BindingContext = new object();
+            Assert.NotEqual(page.BindingContext, behavior.BindingContext);
+
+
+            page.Behaviors.Clear();
+            Assert.Null(behavior.BindingContext);
+
+        }
+
+        public class BehaviorMock : BehaviorBase<Page>
+        {
+
+        }
+
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/BehaviorBaseFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/BehaviorBaseFixture.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-    public class BehaviorBaseFixture
+    public class BehaviorBaseFixture : TestFixture
     {
         [Fact]
         public void FromAttachToDettach()

--- a/MAUI/Source/Kamishibai.Maui.Tests/BehaviorInjectorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/BehaviorInjectorFixture.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using Kamishibai.Maui.Tests.Mocks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+    public class BehaviorInjectorFixture
+    {
+        [Fact]
+        public async void RecursiveInject()
+        {
+            var eventRecoder = new EventRecorder();
+            var tabbedPageMock1 = new TabbedPageMock(eventRecoder);
+            tabbedPageMock1.Children.Add(new ContentPage());
+            var navigationPage = new NavigationPageMock(tabbedPageMock1, eventRecoder);
+
+            var tabbedPageMock2 = new TabbedPageMock(eventRecoder);
+            tabbedPageMock2.Children.Add(new ContentPage());
+
+            await tabbedPageMock1.Navigation.PushAsync(tabbedPageMock2);
+
+            var actual = new BehaviorInjector();
+            actual.Inject(navigationPage);
+
+            Assert.Equal(1, navigationPage.Behaviors.Count);
+            Assert.IsType<NavigationPageBehavior>(navigationPage.Behaviors.Single());
+
+            Assert.Equal(1, tabbedPageMock1.Behaviors.Count);
+            Assert.IsType<MultiPageBehavior<Page>>(tabbedPageMock1.Behaviors.Single());
+
+            Assert.Equal(1, tabbedPageMock2.Behaviors.Count);
+            Assert.IsType<MultiPageBehavior<Page>>(tabbedPageMock2.Behaviors.Single());
+        }
+
+        [Fact]
+        public void Inject_WhenOriginallyExisted()
+        {
+            var navigationPage = new NavigationPage(new ContentPage());
+            var behavior = new NavigationPageBehavior();
+            navigationPage.Behaviors.Add(new BehaviorMock());
+            navigationPage.Behaviors.Add(behavior);
+
+            var injector = new BehaviorInjector();
+            injector.Inject(navigationPage);
+
+            Assert.Equal(2, navigationPage.Behaviors.Count);
+            Assert.Equal(behavior, navigationPage.Behaviors[1]);
+        }
+
+        private class BehaviorMock : Behavior<Page>
+        {
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/BehaviorInjectorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/BehaviorInjectorFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-    public class BehaviorInjectorFixture
+    public class BehaviorInjectorFixture : TestFixture
     {
         [Fact]
         public async void RecursiveInject()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Kamishibai.Maui.Tests.csproj
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Kamishibai.Maui.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<UseMaui>true</UseMaui>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="Moq" Version="4.17.2" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Kamishibai.Maui\Kamishibai.Maui.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/CommonFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/CommonFixture.cs
@@ -1,0 +1,22 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class CommonFixture
+    {
+        [Fact]
+        public void NotNotifiedBindingContext()
+        {
+            var eventReporder = new EventRecorder();
+            var contentPage = new ContentPageMock(eventReporder) { BindingContext = new object() };
+
+            LifecycleNoticeService.OnInitialize(contentPage);
+
+            Assert.Equal(1, eventReporder.Count);
+            Assert.Equal(contentPage, eventReporder[0].Sender);
+            Assert.Equal("OnInitialize", eventReporder[0].CallerMemberName);
+            Assert.Null(eventReporder[0].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnClosedFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnClosedFixture.cs
@@ -1,0 +1,149 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class OnClosedFixture
+    {
+        [Fact]
+        public void ContentPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var contentPageMock = new ContentPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnClosed(contentPageMock);
+
+            Assert.Equal(2, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(viewModelMock, eventRecoder[0].Sender);
+            Assert.Equal("OnClosed", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock, eventRecoder[1].Sender);
+            Assert.Equal("OnClosed", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+        }
+
+        [Fact]
+        public void FlyoutDetailPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var FlyoutDetailPageMock = new FlyoutPageMock(eventRecoder)
+            {
+                Flyout = contentPageMock1,
+                Detail = contentPageMock2,
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnClosed(FlyoutDetailPageMock);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnClosed", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnClosed", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnClosed", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(FlyoutDetailPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnClosed", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NavigationPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder);
+            var contentPageMock2 = new ContentPageMock(eventRecoder);
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+            LifecycleNoticeService.OnClosed(navigationPageMock);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnClosed", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnClosed", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnClosed", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(navigationPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnClosed", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void TabbedPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var tabbedPageMock = new TabbedPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            tabbedPageMock.Children.Add(contentPageMock1);
+            tabbedPageMock.Children.Add(contentPageMock2);
+
+            LifecycleNoticeService.OnClosed(tabbedPageMock);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnClosed", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnClosed", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnClosed", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(tabbedPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnClosed", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnInitializeFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnInitializeFixture.cs
@@ -1,0 +1,216 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class OnInitializeFixture
+    {
+        [Fact]
+        public void ContentPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var contentPageMock = new ContentPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            var parameter = "Hello, Parameter!";
+
+            LifecycleNoticeService.OnInitialize(contentPageMock, parameter);
+
+            Assert.Equal(2, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[1].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[1].Parameter);
+        }
+
+        [Fact]
+        public void FlyoutPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var masterDetailPageMock = new FlyoutPageMock(eventRecoder)
+            {
+                Flyout = contentPageMock1,
+                Detail = contentPageMock2,
+                BindingContext = viewModelMock
+            };
+            var parameter = "Hello, Parameter!";
+
+            LifecycleNoticeService.OnInitialize(masterDetailPageMock, parameter);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(masterDetailPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[1].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[2].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[3].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NavigationPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder);
+            var contentPageMock2ViewModel = new ViewModelMock(eventRecoder);
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { BindingContext = contentPageMock2ViewModel };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            contentPageMock1.Navigation.PushAsync(contentPageMock2);
+            var parameter = "Hello, Parameter!";
+
+            LifecycleNoticeService.OnInitialize(navigationPageMock, parameter);
+
+            Assert.Equal(5, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(navigationPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[1].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[2].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[3].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[3].Parameter);
+
+            Assert.NotNull(eventRecoder[4]);
+            Assert.Equal(contentPageMock2ViewModel, eventRecoder[4].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[4].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[4].Parameter);
+        }
+
+        [Fact]
+        public void TabbedPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var tabbedPageMock = new TabbedPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            tabbedPageMock.Children.Add(contentPageMock1);
+            tabbedPageMock.Children.Add(contentPageMock2);
+            var parameter = "Hello, Parameter!";
+
+            LifecycleNoticeService.OnInitialize(tabbedPageMock, parameter);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(tabbedPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[1].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[2].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnInitialize", eventRecoder[3].CallerMemberName);
+            Assert.Equal(parameter, eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NestedPages()
+        {
+            var tabString = new TabbedPageString();
+            var tabNoParam = new TabbedPageNotParameter();
+            var tabObject = new TabbedPageObject();
+            var contentString = new ContentPageString();
+            tabString.Children.Add(tabNoParam);
+            tabNoParam.Children.Add(tabObject);
+            tabObject.Children.Add(contentString);
+
+            var parameter = "Hello, Parameter!";
+            LifecycleNoticeService.OnInitialize(tabString, parameter);
+
+            Assert.Equal(parameter, tabString.Parameter);
+            Assert.False(tabNoParam.IsCalled);
+            Assert.Equal(parameter, tabObject.Parameter);
+            Assert.Equal(parameter, contentString.Parameter);
+        }
+
+        private class TabbedPageString : TabbedPage, IPageInitializeAware<string>
+        {
+            public string Parameter { get; private set; }
+            public void OnInitialize(string parameter)
+            {
+                Parameter = parameter;
+            }
+        }
+
+        private class TabbedPageNotParameter : TabbedPage, IPageInitializeAware
+        {
+            public bool IsCalled { get; private set; }
+            public void OnInitialize()
+            {
+                IsCalled = true;
+            }
+        }
+
+        private class TabbedPageObject : TabbedPage, IPageInitializeAware<object>
+        {
+            public object Parameter { get; private set; }
+            public void OnInitialize(object parameter)
+            {
+                Parameter = parameter;
+            }
+        }
+
+        private class ContentPageString : ContentPage, IPageInitializeAware<string>
+        {
+            public string Parameter { get; private set; }
+            public void OnInitialize(string parameter)
+            {
+                Parameter = parameter;
+            }
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnLoadedFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnLoadedFixture.cs
@@ -1,0 +1,140 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class OnLoadedFixture
+    {
+        [Fact]
+        public void ContentPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var contentPageMock = new ContentPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnLoaded(contentPageMock);
+
+            Assert.Equal(2, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+        }
+
+        [Fact]
+        public void FlyoutPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var masterDetailPageMock = new FlyoutPageMock(eventRecoder)
+            {
+                Flyout = contentPageMock1,
+                Detail = contentPageMock2,
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnLoaded(masterDetailPageMock);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(masterDetailPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NavigationPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder);
+            var contentPageMock2 = new ContentPageMock(eventRecoder);
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+            LifecycleNoticeService.OnLoaded(navigationPageMock);
+
+            Assert.Equal(3, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(navigationPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock2, eventRecoder[2].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+        }
+
+        [Fact]
+        public void TabbedPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var tabbedPageMock = new TabbedPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            tabbedPageMock.Children.Add(contentPageMock1);
+            tabbedPageMock.Children.Add(contentPageMock2);
+            tabbedPageMock.CurrentPage = contentPageMock2;
+
+            LifecycleNoticeService.OnLoaded(tabbedPageMock);
+
+            Assert.Equal(3, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(tabbedPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock2, eventRecoder[2].Sender);
+            Assert.Equal("OnLoaded", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnResumeFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnResumeFixture.cs
@@ -1,0 +1,149 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class OnResumeFixture
+    {
+        [Fact]
+        public void ContentPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var contentPageMock = new ContentPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnResume(new ApplicationMock { MainPage = contentPageMock });
+
+            Assert.Equal(2, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnResume", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnResume", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+        }
+
+        [Fact]
+        public void FlyoutPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder){ Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder){ Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var masterDetailPageMock = new FlyoutPageMock(eventRecoder)
+            {
+                Flyout = contentPageMock1,
+                Detail = contentPageMock2,
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnResume(new ApplicationMock { MainPage = masterDetailPageMock });
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(masterDetailPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnResume", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnResume", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnResume", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnResume", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NavigationPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder);
+            var contentPageMock2 = new ContentPageMock(eventRecoder);
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+            LifecycleNoticeService.OnResume(new ApplicationMock { MainPage = navigationPageMock });
+
+            Assert.Equal(4, eventRecoder.Count);
+            
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(navigationPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnResume", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+            
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnResume", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnResume", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnResume", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void TabbedPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var tabbedPageMock = new TabbedPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            tabbedPageMock.Children.Add(contentPageMock1);
+            tabbedPageMock.Children.Add(contentPageMock2);
+
+            LifecycleNoticeService.OnResume(new ApplicationMock { MainPage = tabbedPageMock });
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(tabbedPageMock, eventRecoder[0].Sender);
+            Assert.Equal("OnResume", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnResume", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+            Assert.Equal("OnResume", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(contentPageMock2, eventRecoder[3].Sender);
+            Assert.Equal("OnResume", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnSleepFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnSleepFixture.cs
@@ -1,0 +1,149 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class OnSleepFixture
+    {
+        [Fact]
+        public void ContentPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var contentPageMock = new ContentPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnSleep(new ApplicationMock { MainPage = contentPageMock });
+
+            Assert.Equal(2, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(viewModelMock, eventRecoder[0].Sender);
+            Assert.Equal("OnSleep", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock, eventRecoder[1].Sender);
+            Assert.Equal("OnSleep", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+        }
+
+        [Fact]
+        public void FlyoutPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var masterDetailPageMock = new FlyoutPageMock(eventRecoder)
+            {
+                Flyout = contentPageMock1,
+                Detail = contentPageMock2,
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnSleep(new ApplicationMock { MainPage = masterDetailPageMock });
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnSleep", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnSleep", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnSleep", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(masterDetailPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnSleep", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NavigationPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder);
+            var contentPageMock2 = new ContentPageMock(eventRecoder);
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+            LifecycleNoticeService.OnSleep(new ApplicationMock { MainPage = navigationPageMock });
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnSleep", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnSleep", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnSleep", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(navigationPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnSleep", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void TabbedPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var tabbedPageMock = new TabbedPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            tabbedPageMock.Children.Add(contentPageMock1);
+            tabbedPageMock.Children.Add(contentPageMock2);
+
+            LifecycleNoticeService.OnSleep(new ApplicationMock { MainPage = tabbedPageMock });
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnSleep", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnSleep", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnSleep", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(tabbedPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnSleep", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnUnloadedFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Lifecycle/OnUnloadedFixture.cs
@@ -1,0 +1,140 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Lifecycle
+{
+    public class OnUnloadedFixture
+    {
+        [Fact]
+        public void ContentPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var contentPageMock = new ContentPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnUnloaded(contentPageMock);
+
+            Assert.Equal(2, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(viewModelMock, eventRecoder[0].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock, eventRecoder[1].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+        }
+
+        [Fact]
+        public void FlyoutPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var masterDetailPageMock = new FlyoutPageMock(eventRecoder)
+            {
+                Flyout = contentPageMock1,
+                Detail = contentPageMock2,
+                BindingContext = viewModelMock
+            };
+
+            LifecycleNoticeService.OnUnloaded(masterDetailPageMock);
+
+            Assert.Equal(4, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(viewModelMock, eventRecoder[2].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+
+            Assert.NotNull(eventRecoder[3]);
+            Assert.Equal(masterDetailPageMock, eventRecoder[3].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[3].CallerMemberName);
+            Assert.Null(eventRecoder[3].Parameter);
+        }
+
+        [Fact]
+        public void NavigationPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder);
+            var contentPageMock2 = new ContentPageMock(eventRecoder);
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+            LifecycleNoticeService.OnUnloaded(navigationPageMock);
+
+            Assert.Equal(3, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(navigationPageMock, eventRecoder[2].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+        }
+
+        [Fact]
+        public void TabbedPage()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+            var viewModelMock = new ViewModelMock(eventRecoder);
+            var tabbedPageMock = new TabbedPageMock(eventRecoder)
+            {
+                BindingContext = viewModelMock
+            };
+            tabbedPageMock.Children.Add(contentPageMock1);
+            tabbedPageMock.Children.Add(contentPageMock2);
+            tabbedPageMock.CurrentPage = contentPageMock2;
+
+            LifecycleNoticeService.OnUnloaded(tabbedPageMock);
+
+            Assert.Equal(3, eventRecoder.Count);
+
+            Assert.NotNull(eventRecoder[0]);
+            Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[0].CallerMemberName);
+            Assert.Null(eventRecoder[0].Parameter);
+
+            Assert.NotNull(eventRecoder[1]);
+            Assert.Equal(viewModelMock, eventRecoder[1].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[1].CallerMemberName);
+            Assert.Null(eventRecoder[1].Parameter);
+
+            Assert.NotNull(eventRecoder[2]);
+            Assert.Equal(tabbedPageMock, eventRecoder[2].Sender);
+            Assert.Equal("OnUnloaded", eventRecoder[2].CallerMemberName);
+            Assert.Null(eventRecoder[2].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/LifecycleNoticeServiceFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/LifecycleNoticeServiceFixture.cs
@@ -1,0 +1,158 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+    public class LifecycleNoticeServiceFixture
+    {
+        [Fact]
+        public void OnInitialize()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+            var parameter = new object();
+            LifecycleNoticeService.OnInitialize(contentPageMock, parameter);
+
+            Assert.Equal(1, eventRecorder.Count);
+            Assert.Equal(contentPageMock, eventRecorder[0].Sender);
+            Assert.Equal("OnInitialize", eventRecorder[0].CallerMemberName);
+            Assert.Equal(parameter, eventRecorder[0].Parameter);
+        }
+
+        [Fact]
+        public void OnLoaded()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+            LifecycleNoticeService.OnLoaded(contentPageMock);
+
+            Assert.Equal(1, eventRecorder.Count);
+            Assert.Equal(contentPageMock, eventRecorder[0].Sender);
+            Assert.Equal("OnLoaded", eventRecorder[0].CallerMemberName);
+            Assert.Null(eventRecorder[0].Parameter);
+        }
+
+        [Fact]
+        public void OnUnloaded()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+            LifecycleNoticeService.OnUnloaded(contentPageMock);
+
+            Assert.Equal(1, eventRecorder.Count);
+            Assert.Equal(contentPageMock, eventRecorder[0].Sender);
+            Assert.Equal("OnUnloaded", eventRecorder[0].CallerMemberName);
+            Assert.Null(eventRecorder[0].Parameter);
+        }
+
+        [Fact]
+        public void OnClosed()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+            LifecycleNoticeService.OnClosed(contentPageMock);
+
+            Assert.Equal(1, eventRecorder.Count);
+            Assert.Equal(contentPageMock, eventRecorder[0].Sender);
+            Assert.Equal("OnClosed", eventRecorder[0].CallerMemberName);
+            Assert.Null(eventRecorder[0].Parameter);
+        }
+
+        [Fact]
+        public void OnResume()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock = new ContentPageMock(eventRecorder);
+
+            var application = new ApplicationMock { MainPage = contentPageMock };
+
+            LifecycleNoticeService.OnResume(application);
+
+            Assert.Equal(1, eventRecorder.Count);
+            Assert.Equal(contentPageMock, eventRecorder[0].Sender);
+            Assert.Equal("OnResume", eventRecorder[0].CallerMemberName);
+            Assert.Null(eventRecorder[0].Parameter);
+        }
+
+        [Fact]
+        public void OnResume_WithModalStackPages()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecorder);
+
+            var application = new ApplicationMock { MainPage = contentPageMock1 };
+
+            var contentPageMock2 = new ContentPageMock(eventRecorder);
+            contentPageMock1.Navigation.PushModalAsync(contentPageMock2);
+            
+            var contentPageMock3 = new ContentPageMock(eventRecorder);
+            contentPageMock2.Navigation.PushModalAsync(contentPageMock3);
+
+            LifecycleNoticeService.OnResume(application);
+
+            Assert.Equal(3, eventRecorder.Count);
+            
+            Assert.Equal(contentPageMock1, eventRecorder[0].Sender);
+            Assert.Equal("OnResume", eventRecorder[0].CallerMemberName);
+            Assert.Null(eventRecorder[0].Parameter);
+            
+            Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+            Assert.Equal("OnResume", eventRecorder[1].CallerMemberName);
+            Assert.Null(eventRecorder[1].Parameter);
+
+            Assert.Equal(contentPageMock3, eventRecorder[2].Sender);
+            Assert.Equal("OnResume", eventRecorder[2].CallerMemberName);
+            Assert.Null(eventRecorder[2].Parameter);
+        }
+
+        [Fact]
+        public void OnSleep()
+        {
+            lock (ApplicationServiceFixture.ApplicationMock)
+            {
+                var eventRecorder = new EventRecorder();
+                var contentPageMock = new ContentPageMock(eventRecorder);
+
+                var application = new ApplicationMock { MainPage = contentPageMock };
+
+                LifecycleNoticeService.OnSleep(application);
+
+                Assert.Equal(1, eventRecorder.Count);
+                Assert.Equal(contentPageMock, eventRecorder[0].Sender);
+                Assert.Equal("OnSleep", eventRecorder[0].CallerMemberName);
+                Assert.Null(eventRecorder[0].Parameter);
+            }
+        }
+
+        [Fact]
+        public void OnSleep_WithModalStackPages()
+        {
+            var eventRecorder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecorder);
+
+            var application = new ApplicationMock { MainPage = contentPageMock1 };
+
+            var contentPageMock2 = new ContentPageMock(eventRecorder);
+            contentPageMock1.Navigation.PushModalAsync(contentPageMock2);
+
+            var contentPageMock3 = new ContentPageMock(eventRecorder);
+            contentPageMock2.Navigation.PushModalAsync(contentPageMock3);
+
+            LifecycleNoticeService.OnSleep(application);
+
+            Assert.Equal(3, eventRecorder.Count);
+
+            Assert.Equal(contentPageMock3, eventRecorder[0].Sender);
+            Assert.Equal("OnSleep", eventRecorder[0].CallerMemberName);
+            Assert.Null(eventRecorder[0].Parameter);
+
+            Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+            Assert.Equal("OnSleep", eventRecorder[1].CallerMemberName);
+            Assert.Null(eventRecorder[1].Parameter);
+
+            Assert.Equal(contentPageMock1, eventRecorder[2].Sender);
+            Assert.Equal("OnSleep", eventRecorder[2].CallerMemberName);
+            Assert.Null(eventRecorder[2].Parameter);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/LifecycleNoticeServiceFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/LifecycleNoticeServiceFixture.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-    public class LifecycleNoticeServiceFixture
+    public class LifecycleNoticeServiceFixture : TestFixture
     {
         [Fact]
         public void OnInitialize()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ApplicationMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ApplicationMock.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Moq;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class ApplicationMock : Application
+    {
+        static ApplicationMock()
+        {
+            DependencyService.Register<ISystemResourcesProvider, SystemResourcesProvider>();
+        }
+
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class SystemResourcesProvider : ISystemResourcesProvider
+        {
+            // ReSharper disable once CollectionNeverUpdated.Local
+            readonly IList<KeyValuePair<string, object>> _keyValuePairs = new List<KeyValuePair<string, object>>();
+            public IResourceDictionary GetSystemResources()
+            {
+                var resourceDictionaryMock = new Mock<IResourceDictionary>();
+	            resourceDictionaryMock.Setup(m => m.GetEnumerator()).Returns(() => _keyValuePairs.GetEnumerator());
+                return resourceDictionaryMock.Object;
+            }
+        }
+
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ApplicationMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ApplicationMock.cs
@@ -2,6 +2,7 @@
 using Moq;
 using Microsoft.Maui.Controls;
 using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui;
 
 namespace Kamishibai.Maui.Tests.Mocks
 {
@@ -10,6 +11,13 @@ namespace Kamishibai.Maui.Tests.Mocks
         static ApplicationMock()
         {
             DependencyService.Register<ISystemResourcesProvider, SystemResourcesProvider>();
+        }
+
+        public ApplicationMock()
+        {
+            // Create fake main page to make CreateWindow happy.
+            this.MainPage = new Page();
+            ((IApplication)this).CreateWindow(null);
         }
 
         // ReSharper disable once ClassNeverInstantiated.Local

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ContentPageMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ContentPageMock.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class ContentPageMock : ContentPage, IPageLifecycleAware, IApplicationLifecycleAware, IPageInitializeAware<object>
+    {
+        private readonly EventRecorder _eventRecorder;
+
+        public ContentPageMock(EventRecorder eventRecorder)
+        {
+            _eventRecorder = eventRecorder;
+        }
+
+        public void OnInitialize()
+        {
+            _eventRecorder.Record(this);
+        }
+        public void OnInitialize(object parameter)
+        {
+            _eventRecorder.Record(this, parameter);
+        }
+        public void OnLoaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnUnloaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnClosed()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnResume()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnSleep()
+        {
+            _eventRecorder.Record(this);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/DispatcherStub.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/DispatcherStub.cs
@@ -1,0 +1,153 @@
+﻿using Microsoft.Maui.Dispatching;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+	class DispatcherStub : IDispatcher
+	{
+		readonly Func<bool>? _isInvokeRequired;
+		readonly Action<Action>? _invokeOnMainThread;
+
+		public DispatcherStub(Func<bool>? isInvokeRequired, Action<Action>? invokeOnMainThread)
+		{
+			_isInvokeRequired = isInvokeRequired;
+			_invokeOnMainThread = invokeOnMainThread;
+
+			ManagedThreadId = Environment.CurrentManagedThreadId;
+		}
+
+		public bool IsDispatchRequired =>
+			_isInvokeRequired?.Invoke() ?? false;
+
+		public int ManagedThreadId { get; }
+
+		public bool Dispatch(Action action)
+		{
+			if (_invokeOnMainThread is null)
+				action();
+			else
+				_invokeOnMainThread.Invoke(action);
+			return true;
+		}
+
+		public bool DispatchDelayed(TimeSpan delay, Action action)
+		{
+			Timer? timer = null;
+
+			timer = new Timer(OnTimeout, null, delay, delay);
+
+			return true;
+
+			void OnTimeout(object? state)
+			{
+				Dispatch(action);
+
+				timer?.Dispose();
+			}
+		}
+
+		public IDispatcherTimer CreateTimer()
+		{
+			return new DispatcherTimerStub(this);
+		}
+	}
+
+	class DispatcherTimerStub : IDispatcherTimer
+	{
+		readonly DispatcherStub _dispatcher;
+
+		Timer? _timer;
+
+		public DispatcherTimerStub(DispatcherStub dispatcher)
+		{
+			_dispatcher = dispatcher;
+		}
+
+		public TimeSpan Interval { get; set; }
+
+		public bool IsRepeating { get; set; }
+
+		public bool IsRunning => _timer != null;
+
+		public event EventHandler? Tick;
+
+		public void Start()
+		{
+			_timer = new Timer(OnTimeout, null, Interval, IsRepeating ? Interval : Timeout.InfiniteTimeSpan);
+
+			void OnTimeout(object? state)
+			{
+				_dispatcher.Dispatch(() => Tick?.Invoke(this, EventArgs.Empty));
+			}
+		}
+
+		public void Stop()
+		{
+			_timer?.Dispose();
+			_timer = null;
+		}
+	}
+
+	class DispatcherProviderStub : IDispatcherProvider, IDisposable
+	{
+		ThreadLocal<IDispatcher?> s_dispatcherInstance = new(() =>
+			DispatcherProviderStubOptions.SkipDispatcherCreation
+				? null
+				: new DispatcherStub(
+					DispatcherProviderStubOptions.IsInvokeRequired,
+					DispatcherProviderStubOptions.InvokeOnMainThread));
+
+		public void Dispose() =>
+			s_dispatcherInstance.Dispose();
+
+		public IDispatcher? GetForCurrentThread() =>
+			s_dispatcherInstance.Value;
+	}
+
+	public class DispatcherProviderStubOptions
+	{
+		[ThreadStatic]
+		public static bool SkipDispatcherCreation;
+
+		[ThreadStatic]
+		public static Func<bool>? IsInvokeRequired;
+
+		[ThreadStatic]
+		public static Action<Action>? InvokeOnMainThread;
+	}
+
+	public static class DispatcherTest
+	{
+		public static Task Run(Action testAction) =>
+			Run(() =>
+			{
+				testAction();
+				return Task.CompletedTask;
+			});
+
+		public static Task Run(Func<Task> testAction)
+		{
+			var tcs = new TaskCompletionSource();
+
+			var thread = new Thread(async () =>
+			{
+				try
+				{
+					await testAction();
+
+					tcs.SetResult();
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+			thread.Start();
+
+			return tcs.Task;
+		}
+	}
+}
+

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/EventRecord.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/EventRecord.cs
@@ -1,0 +1,9 @@
+﻿namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class EventRecord
+    {
+        public object Sender { get; set; }
+        public object Parameter { get; set; }
+        public string CallerMemberName { get; set; }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/EventRecorder.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/EventRecorder.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class EventRecorder : List<EventRecord>
+    {
+        public void Record(object sender, [CallerMemberName] string callerMemberName = null)
+        {
+            Add(new EventRecord{ Sender = sender, CallerMemberName = callerMemberName});
+        }
+
+        public void Record(object sender, object parameter, [CallerMemberName] string callerMemberName = null)
+        {
+            Add(new EventRecord { Sender = sender, Parameter = parameter, CallerMemberName = callerMemberName });
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/FlyoutPageMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/FlyoutPageMock.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class FlyoutPageMock : FlyoutPage, IPageLifecycleAware<string>, IApplicationLifecycleAware
+    {
+        private readonly EventRecorder _eventRecorder;
+
+        public FlyoutPageMock(EventRecorder eventRecorder)
+        {
+            _eventRecorder = eventRecorder;
+        }
+
+        public void OnInitialize(string param)
+        {
+            _eventRecorder.Record(this, parameter:param);
+        }
+
+        public void OnLoaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnUnloaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnClosed()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnResume()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnSleep()
+        {
+            _eventRecorder.Record(this);
+        }
+
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/NavigationPageMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/NavigationPageMock.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class NavigationPageMock : NavigationPage, IPageLifecycleAware<string>, IApplicationLifecycleAware
+    {
+        private readonly EventRecorder _eventRecorder;
+
+        public NavigationPageMock(Page page, EventRecorder eventRecorder) : base(page)
+        {
+            _eventRecorder = eventRecorder;
+        }
+
+        public void OnInitialize(string param)
+        {
+            _eventRecorder.Record(this, parameter: param);
+        }
+
+        public void OnLoaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnUnloaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnClosed()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnResume()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnSleep()
+        {
+            _eventRecorder.Record(this);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/TabbedPageMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/TabbedPageMock.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class TabbedPageMock : TabbedPage, IPageLifecycleAware<string>, IApplicationLifecycleAware
+    {
+        private readonly EventRecorder _eventRecorder;
+
+        public TabbedPageMock(EventRecorder eventRecorder)
+        {
+            _eventRecorder = eventRecorder;
+        }
+
+        public void OnInitialize(string param)
+        {
+            _eventRecorder.Record(this, parameter: param);
+        }
+
+        public void OnLoaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnUnloaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnClosed()
+        {
+            _eventRecorder.Record(this);
+        }
+        public void OnResume()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnSleep()
+        {
+            _eventRecorder.Record(this);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ViewModelMock.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mocks/ViewModelMock.cs
@@ -1,0 +1,47 @@
+﻿namespace Kamishibai.Maui.Tests.Mocks
+{
+    public class ViewModelMock : IPageLifecycleAware, IApplicationLifecycleAware, IPageInitializeAware<string>
+    {
+        private readonly EventRecorder _eventRecorder;
+
+        public ViewModelMock(EventRecorder eventRecorder)
+        {
+            _eventRecorder = eventRecorder;
+        }
+
+        public void OnInitialize()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnInitialize(string param)
+        {
+            _eventRecorder.Record(this, parameter:param);
+        }
+
+        public void OnLoaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnUnloaded()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnClosed()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnResume()
+        {
+            _eventRecorder.Record(this);
+        }
+
+        public void OnSleep()
+        {
+            _eventRecorder.Record(this);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/MultiPageBehaviorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/MultiPageBehaviorFixture.cs
@@ -1,0 +1,152 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+	public class MultiPageBehaviorFixture
+	{
+		[Fact]
+		public void OnCurrentPageChanged()
+		{
+			var eventRecoder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+			var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+			var tabbedPageMock = new TabbedPageMock(eventRecoder);
+			tabbedPageMock.Children.Add(contentPageMock1);
+			tabbedPageMock.Children.Add(contentPageMock2);
+
+			tabbedPageMock.Behaviors.Add(new MultiPageBehavior<Page>());
+
+			tabbedPageMock.CurrentPage = contentPageMock2;
+			
+			Assert.Equal(2, eventRecoder.Count);
+
+			Assert.NotNull(eventRecoder[0]);
+			Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+			Assert.Equal("OnLoaded", eventRecoder[0].CallerMemberName);
+			Assert.Null(eventRecoder[0].Parameter);
+
+			Assert.NotNull(eventRecoder[1]);
+			Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+			Assert.Equal("OnUnloaded", eventRecoder[1].CallerMemberName);
+			Assert.Null(eventRecoder[1].Parameter);
+		}
+
+	    [Fact]
+	    public void OnCurrentPageChanged_ToNull()
+	    {
+	        var eventRecoder = new EventRecorder();
+	        var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+	        var tabbedPageMock = new TabbedPageMock(eventRecoder);
+	        tabbedPageMock.Children.Add(contentPageMock1);
+
+	        tabbedPageMock.Behaviors.Add(new MultiPageBehavior<Page>());
+
+            tabbedPageMock.Children.Clear();
+
+	        Assert.Equal(2, eventRecoder.Count);
+
+	        Assert.NotNull(eventRecoder[0]);
+	        Assert.Equal(contentPageMock1, eventRecoder[0].Sender);
+	        Assert.Equal("OnClosed", eventRecoder[0].CallerMemberName);
+	        Assert.Null(eventRecoder[0].Parameter);
+        }
+
+	    [Fact]
+	    public void OnCurrentPageChanged_ToNotNull()
+	    {
+	        var eventRecoder = new EventRecorder();
+	        var tabbedPageMock = new TabbedPageMock(eventRecoder);
+
+	        tabbedPageMock.Behaviors.Add(new MultiPageBehavior<Page>());
+
+	        var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+	        tabbedPageMock.Children.Add(contentPageMock1);
+
+            Assert.Equal(2, eventRecoder.Count);
+
+	        Assert.NotNull(eventRecoder[0]);
+	        Assert.Equal(contentPageMock1, eventRecoder[0].Sender);
+	        Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+	        Assert.Null(eventRecoder[0].Parameter);
+
+	        Assert.NotNull(eventRecoder[1]);
+	        Assert.Equal(contentPageMock1, eventRecoder[1].Sender);
+	        Assert.Equal("OnLoaded", eventRecoder[1].CallerMemberName);
+	        Assert.Null(eventRecoder[1].Parameter);
+	    }
+
+        [Fact]
+		public void OnPagesChanged_WhenAddChild()
+		{
+			var eventRecoder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+			var tabbedPageMock = new TabbedPageMock(eventRecoder);
+			tabbedPageMock.Children.Add(contentPageMock1);
+
+			tabbedPageMock.Behaviors.Add(new MultiPageBehavior<Page>());
+
+			var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+			tabbedPageMock.Children.Add(contentPageMock2);
+
+			Assert.Equal(1, eventRecoder.Count);
+
+			Assert.NotNull(eventRecoder[0]);
+			Assert.Equal(contentPageMock2, eventRecoder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+			Assert.Null(eventRecoder[0].Parameter);
+		}
+
+		[Fact]
+		public void OnPagesChanged_WhenRemoveChild()
+		{
+			var eventRecoder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+			var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+			var tabbedPageMock = new TabbedPageMock(eventRecoder);
+			tabbedPageMock.Children.Add(contentPageMock1);
+			tabbedPageMock.Children.Add(contentPageMock2);
+
+			tabbedPageMock.Behaviors.Add(new MultiPageBehavior<Page>());
+
+			tabbedPageMock.Children.Remove(contentPageMock1);
+
+			Assert.Equal(3, eventRecoder.Count);
+
+			Assert.NotNull(eventRecoder[0]);
+			Assert.Equal(contentPageMock1, eventRecoder[0].Sender);
+			Assert.Equal("OnClosed", eventRecoder[0].CallerMemberName);
+			Assert.Null(eventRecoder[0].Parameter);
+
+			Assert.NotNull(eventRecoder[1]);
+			Assert.Equal(contentPageMock2, eventRecoder[1].Sender);
+			Assert.Equal("OnLoaded", eventRecoder[1].CallerMemberName);
+			Assert.Null(eventRecoder[1].Parameter);
+
+			Assert.NotNull(eventRecoder[2]);
+			Assert.Equal(contentPageMock1, eventRecoder[2].Sender);
+			Assert.Equal("OnUnloaded", eventRecoder[2].CallerMemberName);
+			Assert.Null(eventRecoder[2].Parameter);
+		}
+
+		[Fact]
+		public void OnDetachingFrom()
+		{
+			var eventRecoder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+			var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+			var tabbedPageMock = new TabbedPageMock(eventRecoder);
+			tabbedPageMock.Children.Add(contentPageMock1);
+			tabbedPageMock.Children.Add(contentPageMock2);
+
+			tabbedPageMock.Behaviors.Add(new MultiPageBehavior<Page>());
+			tabbedPageMock.Behaviors.Clear();
+
+			tabbedPageMock.CurrentPage = contentPageMock2;
+
+			Assert.Equal(0, eventRecoder.Count);
+		}
+
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/MultiPageBehaviorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/MultiPageBehaviorFixture.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-	public class MultiPageBehaviorFixture
+	public class MultiPageBehaviorFixture : TestFixture
 	{
 		[Fact]
 		public void OnCurrentPageChanged()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/AnimatableNavigationFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/AnimatableNavigationFixture.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Kamishibai.Maui.Mvvm;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class AnimatableNavigationFixture
+	{
+		[Fact]
+		public void Animated()
+		{
+			var mock = new AnimatableNavigationMock();
+			Assert.True(mock.Animated);
+			mock.Animated = false;
+			Assert.False(mock.Animated);
+		}
+		private class AnimatableNavigationMock : AnimatableNavigation<ContentPage>
+		{
+			public override Task Navigate<T>(T parameter = default(T))
+			{
+				throw new NotImplementedException();
+			}
+		}
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/AnimatableNavigationFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/AnimatableNavigationFixture.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class AnimatableNavigationFixture
+	public class AnimatableNavigationFixture : TestFixture
 	{
 		[Fact]
 		public void Animated()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/InsertPageBeforeFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/InsertPageBeforeFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-    public class InsertPageBeforeFixture
+    public class InsertPageBeforeFixture : TestFixture
     {
         [Fact]
         public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/InsertPageBeforeFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/InsertPageBeforeFixture.cs
@@ -1,0 +1,34 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+    public class InsertPageBeforeFixture
+    {
+        [Fact]
+        public void Navigate()
+        {
+            var contentPageA = new ContentPageA();
+            // ReSharper disable once UnusedVariable
+            var navigationPage = new NavigationPage(contentPageA);
+            var contentPageB = new ContentPageB();
+            contentPageA.Navigation.PushAsync(contentPageB);
+
+            var insertPageBefore = new InsertPageBefore<ContentPageC, ContentPageB>();
+            var navigatorMock = new Mock<INavigator>();
+            insertPageBefore.Navigator = navigatorMock.Object;
+            contentPageB.Behaviors.Add(insertPageBefore);
+
+            var parameter = "Hello, Parameter!";
+            insertPageBefore.Navigate(parameter);
+
+			navigatorMock.Verify(m => m.InsertPageBefore(It.IsAny<ContentPageC>(), contentPageB, parameter), Times.Once);
+        }
+
+        private class ContentPageA : ContentPage { }
+        private class ContentPageB : ContentPage { }
+        private class ContentPageC : ContentPage { }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationBehaviorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationBehaviorFixture.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class NavigationBehaviorFixture
+	public class NavigationBehaviorFixture : TestFixture
 	{
 		[Fact]
 		public void OnAttachedTo()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationBehaviorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationBehaviorFixture.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Kamishibai.Maui.Mvvm;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class NavigationBehaviorFixture
+	{
+		[Fact]
+		public void OnAttachedTo()
+		{
+			var contentPage1 = new ContentPage();
+			var navigationBehavior = new NavigationBehaviorMock<ContentPage>();
+			contentPage1.Behaviors.Add(navigationBehavior);
+			
+			Assert.NotNull(navigationBehavior.Navigator);
+
+			var contentPage2 = new ContentPage();
+			navigationBehavior.Navigator.PushModalAsync(contentPage2);
+			
+			Assert.Equal(1, contentPage1.Navigation.ModalStack.Count);
+			Assert.Equal(contentPage2, contentPage1.Navigation.ModalStack.Single());
+		}
+
+	    [Fact]
+	    public void Navigate()
+	    {
+	        var navigationRequest = new NavigationRequest();
+	        var navigationActionMock = new NavigationBehaviorMock<ContentPage> { Request = navigationRequest };
+
+            navigationRequest.RaiseAsync();
+
+	        Assert.Equal(navigationRequest, navigationActionMock.Request);
+
+	        Assert.True(navigationActionMock.Navigated);
+	        Assert.Equal(typeof(object), navigationActionMock.ParameterType);
+	        Assert.Null(navigationActionMock.Parameter);
+	    }
+
+	    [Fact]
+	    public void Navigate_WithParameter()
+	    {
+	        var navigationRequest = new NavigationRequest<string>();
+	        var navigationActionMock = new NavigationBehaviorMock<ContentPage> { Request = navigationRequest };
+
+            var parameter = "Hello, Parameter!";
+	        navigationRequest.RaiseAsync(parameter);
+
+	        Assert.Equal(navigationRequest, navigationActionMock.Request);
+
+	        Assert.True(navigationActionMock.Navigated);
+	        Assert.Equal(typeof(string), navigationActionMock.ParameterType);
+	        Assert.Equal(parameter, navigationActionMock.Parameter);
+	    }
+
+	    [Fact]
+	    public async void NavigationRequestPropertyChanged_ToNull()
+	    {
+	        var navigationRequest = new NavigationRequest();
+	        var navigationActionMock = new NavigationBehaviorMock<ContentPage> { Request = navigationRequest };
+
+	        navigationActionMock.Request = null;
+	        Assert.Null(navigationActionMock.Request);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => navigationRequest.RaiseAsync());
+
+
+	        Assert.False(navigationActionMock.Navigated);
+	        Assert.Null(navigationActionMock.ParameterType);
+	        Assert.Null(navigationActionMock.Parameter);
+        }
+
+
+        private class NavigationBehaviorMock<TNavigatePage> : NavigationBehavior<TNavigatePage> where TNavigatePage : Page, new()
+	    {
+	        public bool Navigated { get; private set; }
+	        public Type ParameterType { get; private set; }
+	        public object Parameter { get; private set; }
+	        public override Task Navigate<T>(T parameter = default(T))
+	        {
+	            Navigated = true;
+	            ParameterType = typeof(T);
+	            Parameter = parameter;
+	            return Task.FromResult(true);
+	        }
+	    }
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommandFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommandFixture.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Kamishibai.Maui.Mvvm;
+using Moq;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class NavigationRequestCommandFixture
+	{
+		[Fact]
+		public void DefaultConstructor()
+		{
+			var command = new NavigationRequestCommand();
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute(new object()));
+
+			command.Execute(new object());
+			actionMock.Verify(m => m.Navigate<object>(null), Times.Once);
+		}
+
+		[Fact]
+		public void Constructor_WithNonParameterAction()
+		{
+			var called = false;
+			var command = new NavigationRequestCommand(() => called = true);
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute(new object()));
+			
+			var parameter = new object();
+
+			command.Execute(parameter);
+			actionMock.Verify(m => m.Navigate((object)null), Times.Once);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void Constructor_WithNonParameterActionAndFunc()
+		{
+			var called = false;
+			var command = new NavigationRequestCommand(() => called = true, () => true);
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute(new object()));
+
+			command.Execute(new object());
+			actionMock.Verify(m => m.Navigate((object)null), Times.Once);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void Constructor_WithAction()
+		{
+			var called = false;
+			var command = new NavigationRequestCommand(() => called = true);
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute(new object()));
+
+			var parameter = new object();
+
+			command.Execute(parameter);
+			actionMock.Verify(m => m.Navigate((object)null), Times.Once);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void Constructor_WithActionAndFunc()
+		{
+		    var command = new NavigationRequestCommand(() => { }, () => false);
+			Assert.False(command.CanExecute(new object()));
+		}
+
+	    [Fact]
+	    public void Constructor_WhenExecuteIsNull()
+	    {
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand(null));
+	    }
+
+	    [Fact]
+	    public void Constructor_WhenCanExecuteIsNull()
+	    {
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand(() => { }, null));
+	    }
+
+        [Fact]
+	    public void ChangeCanExecute()
+	    {
+	        var command = new NavigationRequestCommand();
+	        var called = false;
+
+	        command.ChangeCanExecute(); // Exception does not occur.
+
+            command.CanExecuteChanged += (sender, args) => called = true;
+
+	        command.ChangeCanExecute();
+
+            Assert.True(called);
+	    }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommandFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommandFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class NavigationRequestCommandFixture
+	public class NavigationRequestCommandFixture : TestFixture
 	{
 		[Fact]
 		public void DefaultConstructor()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommand{T}Fixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommand{T}Fixture.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using Kamishibai.Maui.Mvvm;
+using Moq;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class NavigationRequestCommandTFixture
+	{
+		[Fact]
+		public void DefaultConstructor()
+		{
+			var command = new NavigationRequestCommand<string>();
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			var parameter = "Hello, Parameter!";
+
+			Assert.True(command.CanExecute());
+			Assert.True(command.CanExecute(parameter));
+			Assert.True(command.CanExecute((object)parameter));
+			Assert.True(command.CanExecute(new object()));
+
+			command.Execute();
+			actionMock.Verify(m => m.Navigate<string>(null), Times.Once);
+
+			command.Execute(new object());
+			actionMock.Verify(m => m.Navigate<string>(null), Times.Exactly(2));
+
+			command.Execute(parameter);
+			actionMock.Verify(m => m.Navigate(parameter), Times.Once);
+
+			command.Execute((object)parameter);
+			actionMock.Verify(m => m.Navigate(parameter), Times.Exactly(2));
+		}
+
+		[Fact]
+		public void Constructor_WithNonParameterAction()
+		{
+			var called = false;
+			var command = new NavigationRequestCommand<string>(() => called = true);
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute());
+			
+			var parameter = "Hello, Parameter!";
+
+			command.Execute(parameter);
+			actionMock.Verify(m => m.Navigate(parameter), Times.Once);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void Constructor_WithNonParameterActionAndFunc()
+		{
+			var called = false;
+			var command = new NavigationRequestCommand<string>(() => called = true, () => true);
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute());
+
+			command.Execute();
+			actionMock.Verify(m => m.Navigate((object)null), Times.Once);
+			Assert.True(called);
+		}
+
+		[Fact]
+		public void Constructor_WithAction()
+		{
+			string actionParameter = null;
+			var command = new NavigationRequestCommand<string>(args => actionParameter = args);
+			var actionMock = new Mock<INavigationAction>();
+			command.NavigationAction = actionMock.Object;
+
+			Assert.True(command.CanExecute());
+
+			var parameter = "Hello, Parameter!";
+
+			command.Execute(parameter);
+			actionMock.Verify(m => m.Navigate(parameter), Times.Once);
+			Assert.Equal(parameter, actionParameter);
+		}
+
+		[Fact]
+		public void Constructor_WithActionAndFunc()
+		{
+			string funcParameter = null;
+			var command = new NavigationRequestCommand<string>(_ => { }, args =>
+			{
+				funcParameter = args;
+				return false;
+			});
+
+			var parameter = "Hello, Parameter!";
+			Assert.False(command.CanExecute(parameter));
+			Assert.Equal(parameter, funcParameter);
+		}
+
+		[Fact]
+		public void ChangeCanExecute()
+		{
+			var command = new NavigationRequestCommand<string>();
+			var called = false;
+		    command.ChangeCanExecute(); // Exception does not occur.
+
+            command.CanExecuteChanged += (sender, args) => called = true;
+			command.ChangeCanExecute();
+			Assert.True(called);
+		}
+
+	    [Fact]
+	    public void Constructor_WhenExecuteIsNull()
+	    {
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand<string>((Action)null));
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand<string>(null, () => true));
+	    }
+
+        [Fact]
+	    public void Constructor_WhenCanExecuteIsNull()
+	    {
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand<string>(() => { }, null));
+	    }
+
+	    [Fact]
+	    public void Constructor_WhenExecuteWithTypeParameterIsNull()
+	    {
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand<string>((Action<string>)null));
+	    }
+
+	    [Fact]
+	    public void Constructor_WhenCanExecuteWithTypeParameterIsNull()
+	    {
+	        Assert.Throws<ArgumentNullException>(() => new NavigationRequestCommand<string>(_ => { }, null));
+	    }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommand{T}Fixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestCommand{T}Fixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class NavigationRequestCommandTFixture
+	public class NavigationRequestCommandTFixture : TestFixture
 	{
 		[Fact]
 		public void DefaultConstructor()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class NavigationRequestFixture
+	public class NavigationRequestFixture : TestFixture
 	{
 		[Fact]
 		public void RaiseAsync()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/NavigationRequestFixture.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Kamishibai.Maui.Mvvm;
+using Moq;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class NavigationRequestFixture
+	{
+		[Fact]
+		public void RaiseAsync()
+		{
+			var navigationRequest = new NavigationRequest();
+			var actionMock = new Mock<INavigationAction>();
+			navigationRequest.NavigationAction = actionMock.Object;
+			navigationRequest.RaiseAsync();
+			
+			actionMock.Verify(m => m.Navigate<object>(null), Times.Once);
+		}
+
+	    [Fact]
+	    public async void RaiseAsync_WhenNavigationActionIsNull()
+	    {
+	        var navigationRequest = new NavigationRequest();
+	        await Assert.ThrowsAsync<InvalidOperationException>(() => navigationRequest.RaiseAsync());
+	    }
+
+		[Fact]
+		public void RaiseAsync_WithParameter()
+		{
+			var navigationRequest = new NavigationRequest<string>();
+			var actionMock = new Mock<INavigationAction>();
+			navigationRequest.NavigationAction = actionMock.Object;
+			var parameter = "Hello, Parameter!";
+			navigationRequest.RaiseAsync(parameter);
+
+			actionMock.Verify(m => m.Navigate(parameter), Times.Once);
+		}
+
+	    [Fact]
+	    public void RaiseAsync_WithNullParameter()
+	    {
+	        var navigationRequest = new NavigationRequest<DateTime>();
+	        var actionMock = new Mock<INavigationAction>();
+	        navigationRequest.NavigationAction = actionMock.Object;
+	        ((INavigationRequest)navigationRequest).RaiseAsync();
+
+	        actionMock.Verify(m => m.Navigate(default(DateTime)), Times.Once);
+	    }
+
+	    [Fact]
+	    public async void RaiseAsync_WithParameter_WhenNavigationActionIsNull()
+	    {
+	        var navigationRequest = new NavigationRequest<string>();
+	        await Assert.ThrowsAsync<InvalidOperationException>(() => navigationRequest.RaiseAsync("Hello, Parameter!"));
+	    }
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopAsyncFixture.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class PopAsyncFixture
+	public class PopAsyncFixture : TestFixture
 	{
 		[Fact]
 		public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopAsyncFixture.cs
@@ -1,0 +1,22 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class PopAsyncFixture
+	{
+		[Fact]
+		public void Navigate()
+		{
+			var popAsync = new PopAsync();
+		    var navigatorMock = new Mock<INavigator>();
+		    popAsync.Navigator = navigatorMock.Object;
+
+			var parameter = "Hello, Parameter!";
+			popAsync.Navigate(parameter);
+			
+			navigatorMock.Verify(m => m.PopAsync(true), Times.Once);
+		}
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopModalAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopModalAsyncFixture.cs
@@ -1,0 +1,23 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+    public class PopModalAsyncFixture
+    {
+        [Fact]
+        public void Navigate()
+        {
+			
+            var popModalAsync = new PopModalAsync();
+            var navigatorMock = new Mock<INavigator>();
+            popModalAsync.Navigator = navigatorMock.Object;
+
+            var parameter = "Hello, Parameter!";
+            popModalAsync.Navigate(parameter);
+			
+            navigatorMock.Verify(m => m.PopModalAsync(true), Times.Once);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopModalAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopModalAsyncFixture.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-    public class PopModalAsyncFixture
+    public class PopModalAsyncFixture : TestFixture
     {
         [Fact]
         public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopToRootAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopToRootAsyncFixture.cs
@@ -1,0 +1,22 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+    public class PopToRootAsyncFixture
+    {
+        [Fact]
+        public void Navigate()
+        {
+            var popToRootAsync = new PopToRootAsync();
+            var navigatorMock = new Mock<INavigator>();
+            popToRootAsync.Navigator = navigatorMock.Object;
+
+            var parameter = "Hello, Parameter!";
+            popToRootAsync.Navigate(parameter);
+			
+            navigatorMock.Verify(m => m.PopToRootAsync(true), Times.Once);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopToRootAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PopToRootAsyncFixture.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-    public class PopToRootAsyncFixture
+    public class PopToRootAsyncFixture : TestFixture
     {
         [Fact]
         public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushAsyncFixture.cs
@@ -1,0 +1,23 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+    public class PushAsyncFixture
+    {
+        [Fact]
+        public void Navigate()
+        {
+            var pushAsync = new PushAsync<ContentPage>();
+            var navigatorMock = new Mock<INavigator>();
+            pushAsync.Navigator = navigatorMock.Object;
+
+            var parameter = "Hello, Parameter!";
+            pushAsync.Navigate(parameter);
+			
+            navigatorMock.Verify(m => m.PushAsync(It.IsAny<ContentPage>(), parameter, true), Times.Once);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushAsyncFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-    public class PushAsyncFixture
+    public class PushAsyncFixture : TestFixture
     {
         [Fact]
         public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushModalAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushModalAsyncFixture.cs
@@ -1,0 +1,47 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+    public class PushModalAsyncFixture
+    {
+        [Fact]
+        public void Navigate()
+        {
+            var pushModalAsync = new PushModalAsync<ContentPage>();
+            var navigatorMock = new Mock<INavigator>();
+            pushModalAsync.Navigator = navigatorMock.Object;
+
+            var parameter = "Hello, Parameter!";
+            pushModalAsync.Navigate(parameter);
+			
+            navigatorMock.Verify(m => m.PushModalAsync(It.IsAny<ContentPage>(), parameter, true), Times.Once);
+        }
+
+        [Fact]
+        public void NavigateWithNavigationPage()
+        {
+            var pushModalAsync = new PushModalAsync<ContentPage>{ WithNavigationPage = true };
+            var navigatorMock = new Mock<INavigator>();
+            pushModalAsync.Navigator = navigatorMock.Object;
+
+            var parameter = "Hello, Parameter!";
+
+            NavigationPage navigationPage = null;
+            navigatorMock
+                .Setup(m => m.PushModalAsync(It.IsAny<NavigationPage>(), parameter, true))
+                .Callback<Page, string, bool>((page, param, animated) =>
+                {
+                    navigationPage = page as NavigationPage;
+                });
+            
+            pushModalAsync.Navigate(parameter);
+			
+            navigatorMock.Verify(m => m.PushModalAsync(It.IsAny<NavigationPage>(), parameter, true), Times.Once);
+            Assert.NotNull(navigationPage);
+            Assert.IsType<ContentPage>(navigationPage.CurrentPage);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushModalAsyncFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/PushModalAsyncFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-    public class PushModalAsyncFixture
+    public class PushModalAsyncFixture : TestFixture
     {
         [Fact]
         public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/RemovePageFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/RemovePageFixture.cs
@@ -1,0 +1,56 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class RemovePageFixture
+	{
+		[Fact]
+		public void Navigate()
+		{
+			var contentPageA = new ContentPageA();
+		    // ReSharper disable once UnusedVariable
+			var navigationPage = new NavigationPage(contentPageA);
+			var contentPageB = new ContentPageB();
+			contentPageA.Navigation.PushAsync(contentPageB);
+			var contentPageC = new ContentPageC();
+			contentPageB.Navigation.PushAsync(contentPageC);
+			
+			var removePage = new RemovePage<ContentPageB>();
+		    var navigatorMock = new Mock<INavigator>();
+		    removePage.Navigator = navigatorMock.Object;
+		    contentPageC.Behaviors.Add(removePage);
+
+            var parameter = "Hello, Parameter!";
+			removePage.Navigate(parameter);
+			
+			navigatorMock.Verify(m => m.RemovePage(contentPageB), Times.Once);
+		}
+
+	    [Fact]
+	    public void Navigate_NotExistTarget()
+	    {
+	        var contentPageA = new ContentPageA();
+	        // ReSharper disable once UnusedVariable
+	        var navigationPage = new NavigationPage(contentPageA);
+	        var contentPageB = new ContentPageB();
+	        contentPageA.Navigation.PushAsync(contentPageB);
+
+	        var removePage = new RemovePage<ContentPageC>();
+	        var navigatorMock = new Mock<INavigator>();
+	        removePage.Navigator = navigatorMock.Object;
+	        contentPageB.Behaviors.Add(removePage);
+
+	        var parameter = "Hello, Parameter!";
+	        removePage.Navigate(parameter);
+
+	        navigatorMock.Verify(m => m.RemovePage(It.IsAny<Page>()), Times.Never);
+	    }
+
+		private class ContentPageA : ContentPage {}
+		private class ContentPageB : ContentPage {}
+		private class ContentPageC : ContentPage {}
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/RemovePageFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/RemovePageFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class RemovePageFixture
+	public class RemovePageFixture : TestFixture
 	{
 		[Fact]
 		public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/ServiceLocatorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/ServiceLocatorFixture.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Kamishibai.Maui.Mvvm;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+    public class ServiceLocatorFixture
+    {
+        [Fact]
+        public void SetLocator()
+        {
+            ServiceLocator.SetLocator(type =>
+            {
+                if (type == typeof(Mock))
+                {
+                    return new Mock();
+                }
+                else
+                {
+                    return ServiceLocator.DefaultLocator(type);
+                }
+            });
+        }
+
+        private class Mock
+        {
+            
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/ServiceLocatorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/ServiceLocatorFixture.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-    public class ServiceLocatorFixture
+    public class ServiceLocatorFixture : TestFixture
     {
         [Fact]
         public void SetLocator()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/SetMainPageFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/SetMainPageFixture.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests.Mvvm
 {
-	public class SetMainPageFixture
+	public class SetMainPageFixture : TestFixture
 	{
 		[Fact]
 		public void Navigate()

--- a/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/SetMainPageFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Mvvm/SetMainPageFixture.cs
@@ -1,0 +1,27 @@
+﻿using Kamishibai.Maui.Mvvm;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests.Mvvm
+{
+	public class SetMainPageFixture
+	{
+		[Fact]
+		public void Navigate()
+		{
+		    var mock = ApplicationServiceFixture.ApplicationMock;
+            var setMainPage = new SetMainPage<TestContentPage>();
+		    var navigatorMock = new Mock<INavigator>();
+		    setMainPage.Navigator = navigatorMock.Object;
+
+		    var parameter = "Hello, Parameter!";
+		    setMainPage.Navigate(parameter);
+
+		    mock.VerifySet(m => m.MainPage = It.IsAny<TestContentPage>());
+        }
+
+
+        private class TestContentPage : ContentPage {}
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/NavigationPageBehaviorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/NavigationPageBehaviorFixture.cs
@@ -3,8 +3,8 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-    public class NavigationPageBehaviorFixture
-    {
+    public class NavigationPageBehaviorFixture : TestFixture
+	{
         [Fact]
 		public void OnCurrentPageChanged()
 		{

--- a/MAUI/Source/Kamishibai.Maui.Tests/NavigationPageBehaviorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/NavigationPageBehaviorFixture.cs
@@ -1,0 +1,68 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+    public class NavigationPageBehaviorFixture
+    {
+        [Fact]
+		public void OnCurrentPageChanged()
+		{
+            var eventRecoder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+			var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+			var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder);
+		    contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+		    navigationPageMock.Behaviors.Add(new NavigationPageBehavior());
+
+		    contentPageMock2.Navigation.PopAsync();
+
+			Assert.Equal(2, eventRecoder.Count);
+
+			Assert.NotNull(eventRecoder[0]);
+			Assert.Equal(contentPageMock1, eventRecoder[0].Sender);
+			Assert.Equal("OnLoaded", eventRecoder[0].CallerMemberName);
+			Assert.Null(eventRecoder[0].Parameter);
+
+			Assert.NotNull(eventRecoder[1]);
+			Assert.Equal(contentPageMock2, eventRecoder[1].Sender);
+			Assert.Equal("OnClosed", eventRecoder[1].CallerMemberName);
+			Assert.Null(eventRecoder[1].Parameter);
+
+		}
+
+
+		[Fact]
+		public void OnDetachingFrom()
+		{
+		    var eventRecoder = new EventRecorder();
+		    var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+		    var contentPageMock2 = new ContentPageMock(eventRecoder) { Title = "contentPageMock2" };
+		    var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder);
+		    contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+		    navigationPageMock.Behaviors.Add(new NavigationPageBehavior());
+		    navigationPageMock.Behaviors.Clear();
+
+		    contentPageMock2.Navigation.PopAsync();
+
+            Assert.Equal(0, eventRecoder.Count);
+		}
+
+        [Fact]
+        public void CanNotPop()
+        {
+            var eventRecoder = new EventRecorder();
+            var contentPageMock1 = new ContentPageMock(eventRecoder) { Title = "contentPageMock1" };
+            var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecoder);
+
+            navigationPageMock.Behaviors.Add(new NavigationPageBehavior());
+
+            contentPageMock1.Navigation.PopAsync();
+
+            Assert.Equal(0, eventRecoder.Count);
+        }
+
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/NavigatorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/NavigatorFixture.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Kamishibai.Maui.Tests
 {
-	public class NavigatorFixture
+	public class NavigatorFixture : TestFixture
 	{
 	    [Fact]
 	    public void ModalStack()

--- a/MAUI/Source/Kamishibai.Maui.Tests/NavigatorFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/NavigatorFixture.cs
@@ -1,0 +1,426 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Kamishibai.Maui.Tests.Mocks;
+using Moq;
+using Microsoft.Maui.Controls;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+	public class NavigatorFixture
+	{
+	    [Fact]
+	    public void ModalStack()
+	    {
+	        var contentPage = new ContentPage();
+            var navigationMock = new Mock<INavigation>();
+	        // ReSharper disable once CollectionNeverUpdated.Local
+	        var modalStack = new List<Page>();
+	        navigationMock.SetupGet(m => m.ModalStack).Returns(modalStack);
+
+            var navigator = new Navigator(contentPage, navigationMock.Object);
+
+            Assert.Equal(modalStack, navigator.ModalStack);
+	    }
+
+	    [Fact]
+	    public void NavigationStack()
+	    {
+	        var contentPage = new ContentPage();
+	        var navigationMock = new Mock<INavigation>();
+	        // ReSharper disable once CollectionNeverUpdated.Local
+	        var navigationStack = new List<Page>();
+	        navigationMock.SetupGet(m => m.NavigationStack).Returns(navigationStack);
+
+	        var navigator = new Navigator(contentPage, navigationMock.Object);
+
+	        Assert.Equal(navigationStack, navigator.NavigationStack);
+	    }
+
+        [Fact]
+		public void InsertPageBefore()
+		{
+			var eventRecoder = new EventRecorder();
+			var contentPage1 = new ContentPageMock(eventRecoder);
+			var navigationPage = new NavigationPage(contentPage1);
+			var navigator = new Navigator(contentPage1);
+			var contentPage2 = new ContentPageMock(eventRecoder);
+			navigator.InsertPageBefore(contentPage2, contentPage1);
+			
+			Assert.Equal(2, navigationPage.Navigation.NavigationStack.Count);
+			Assert.Equal(contentPage2, navigationPage.Navigation.NavigationStack[0]);
+			Assert.Equal(contentPage1, navigationPage.Navigation.NavigationStack[1]);
+			
+			Assert.Equal(1, eventRecoder.Count);
+			
+			Assert.Equal(contentPage2, eventRecoder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+			Assert.Null(eventRecoder[0].Parameter);
+		}
+
+		[Fact]
+		public void InsertPageBefore_WithParameter()
+		{
+			var eventRecoder = new EventRecorder();
+			var contentPage1 = new ContentPageMock(eventRecoder);
+			var navigationPage = new NavigationPage(contentPage1);
+			var navigator = new Navigator(contentPage1);
+			var contentPage2 = new ContentPageMock(eventRecoder);
+			var parameter = new object();
+			navigator.InsertPageBefore(contentPage2, contentPage1, parameter);
+
+			Assert.Equal(2, navigationPage.Navigation.NavigationStack.Count);
+			Assert.Equal(contentPage2, navigationPage.Navigation.NavigationStack[0]);
+			Assert.Equal(contentPage1, navigationPage.Navigation.NavigationStack[1]);
+
+			Assert.Equal(1, eventRecoder.Count);
+
+			Assert.Equal(contentPage2, eventRecoder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecoder[0].CallerMemberName);
+			Assert.Equal(parameter, eventRecoder[0].Parameter);
+		}
+
+		[Fact]
+		public void PopAsync()
+		{
+			var navigationMock = new Mock<INavigation>();
+			var navigator = new Navigator(null, navigationMock.Object);
+			navigator.PopAsync();
+			
+			navigationMock.Verify(x => x.PopAsync(true), Times.Once);
+		}
+
+	    [Fact]
+	    public void PopAsync_WhenAnimatedIsFalse()
+	    {
+	        var navigationMock = new Mock<INavigation>();
+	        var navigator = new Navigator(null, navigationMock.Object);
+	        navigator.PopAsync(false);
+
+	        navigationMock.Verify(x => x.PopAsync(false), Times.Once);
+	    }
+
+        [Fact]
+		public void PopModalAsync()
+		{
+			var navigationMock = new Mock<INavigation>();
+			var navigator = new Navigator(null, navigationMock.Object);
+			navigator.PopModalAsync();
+
+			navigationMock.Verify(x => x.PopModalAsync(true), Times.Once);
+		}
+
+	    [Fact]
+	    public void PopModalAsync_WhenAnimatedIsFalse()
+	    {
+	        var navigationMock = new Mock<INavigation>();
+	        var navigator = new Navigator(null, navigationMock.Object);
+	        navigator.PopModalAsync(false);
+
+	        navigationMock.Verify(x => x.PopModalAsync(false), Times.Once);
+	    }
+
+        [Fact]
+		public async Task PopToRootAsync()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder) { Title = "contentPageMock1" };
+			var contentPageMock2 = new ContentPageMock(eventRecorder) { Title = "contentPageMock2" };
+			var contentPageMock3 = new ContentPageMock(eventRecorder) { Title = "contentPageMock3" };
+		    // ReSharper disable once UnusedVariable
+			var navigationPage = new NavigationPageMock(contentPageMock1, eventRecorder);
+			await contentPageMock1.Navigation.PushAsync(contentPageMock2);
+			await contentPageMock2.Navigation.PushAsync(contentPageMock3);
+
+			var navigationMock = new Mock<INavigation>();
+			navigationMock
+				.Setup(m => m.PopToRootAsync(true))
+				.Returns(() => Task.FromResult(true))
+				.Callback(() => contentPageMock3.Navigation.PopToRootAsync(true).Wait());
+
+			var navigator = new Navigator(contentPageMock3, navigationMock.Object);
+			await navigator.PopToRootAsync();
+
+			navigationMock.Verify(x => x.PopToRootAsync(true), Times.Once);
+			
+			Assert.Equal(3, eventRecorder.Count);
+			
+			Assert.Equal(contentPageMock1, eventRecorder[0].Sender);
+			Assert.Equal("OnLoaded", eventRecorder[0].CallerMemberName);
+			Assert.Null(eventRecorder[0].Parameter);
+
+			Assert.Equal(contentPageMock3, eventRecorder[1].Sender);
+			Assert.Equal("OnClosed", eventRecorder[1].CallerMemberName);
+			Assert.Null(eventRecorder[1].Parameter);
+
+			Assert.Equal(contentPageMock2, eventRecorder[2].Sender);
+			Assert.Equal("OnClosed", eventRecorder[2].CallerMemberName);
+			Assert.Null(eventRecorder[2].Parameter);
+		}
+
+	    [Fact]
+	    public async Task PopToRootAsync_WhenAnimatedIsFalse()
+	    {
+	        var eventRecorder = new EventRecorder();
+	        var contentPageMock1 = new ContentPageMock(eventRecorder) { Title = "contentPageMock1" };
+	        var contentPageMock2 = new ContentPageMock(eventRecorder) { Title = "contentPageMock2" };
+	        var contentPageMock3 = new ContentPageMock(eventRecorder) { Title = "contentPageMock3" };
+	        // ReSharper disable once UnusedVariable
+	        var navigationPage = new NavigationPageMock(contentPageMock1, eventRecorder);
+	        await contentPageMock1.Navigation.PushAsync(contentPageMock2);
+	        await contentPageMock2.Navigation.PushAsync(contentPageMock3);
+
+	        var navigationMock = new Mock<INavigation>();
+	        navigationMock
+	            .Setup(m => m.PopToRootAsync(false))
+	            .Returns(() => Task.FromResult(false))
+	            .Callback(() => contentPageMock3.Navigation.PopToRootAsync(false).Wait());
+
+	        var navigator = new Navigator(contentPageMock3, navigationMock.Object);
+	        await navigator.PopToRootAsync(false);
+
+	        navigationMock.Verify(x => x.PopToRootAsync(false), Times.Once);
+	    }
+
+	    [Fact]
+	    public async Task PopToRootAsync_WhenParentIsNotNavigationPage()
+	    {
+	        var eventRecorder = new EventRecorder();
+	        var contentPageMock1 = new ContentPageMock(eventRecorder) { Title = "contentPageMock1" };
+	        var contentPageMock2 = new ContentPageMock(eventRecorder) { Title = "contentPageMock2" };
+	        var contentPageMock3 = new ContentPageMock(eventRecorder) { Title = "contentPageMock3" };
+            var tabbedPage = new TabbedPage();
+            tabbedPage.Children.Add(contentPageMock1);
+	        tabbedPage.Children.Add(contentPageMock2);
+	        tabbedPage.Children.Add(contentPageMock3);
+
+	        var navigationMock = new Mock<INavigation>();
+	        var navigator = new Navigator(contentPageMock3, navigationMock.Object);
+	        await navigator.PopToRootAsync();
+
+            Assert.Equal(0, eventRecorder.Count);
+            navigationMock.Verify(m => m.PopToRootAsync(It.IsAny<bool>()), Times.Never);
+        }
+
+        [Fact]
+		public async Task PushAsync()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder);
+		    // ReSharper disable once UnusedVariable
+			var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecorder);
+			var navigationMock = new Mock<INavigation>();
+			var navigator = new Navigator(contentPageMock1, navigationMock.Object);
+			var behaviorInjectorMock = new Mock<IBehaviorInjector>();
+			navigator.BehaviorInjector = behaviorInjectorMock.Object;
+
+			var contentPageMock2 = new ContentPageMock(eventRecorder);
+			await navigator.PushAsync(contentPageMock2);
+			
+			
+			behaviorInjectorMock.Verify(x => x.Inject(contentPageMock2), Times.Once);
+			navigationMock.Verify(x => x.PushAsync(contentPageMock2, true), Times.Once);
+
+			Assert.Equal(3, eventRecorder.Count);
+
+			Assert.Equal(contentPageMock2, eventRecorder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecorder[0].CallerMemberName);
+			Assert.Null(eventRecorder[0].Parameter);
+
+			Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+			Assert.Equal("OnLoaded", eventRecorder[1].CallerMemberName);
+			Assert.Null(eventRecorder[1].Parameter);
+
+			Assert.Equal(contentPageMock1, eventRecorder[2].Sender);
+			Assert.Equal("OnUnloaded", eventRecorder[2].CallerMemberName);
+			Assert.Null(eventRecorder[2].Parameter);
+		}
+
+	    [Fact]
+	    public async Task PushAsync_WhenAnimatedIsFalse()
+	    {
+	        var eventRecorder = new EventRecorder();
+	        var contentPageMock1 = new ContentPageMock(eventRecorder);
+	        // ReSharper disable once UnusedVariable
+	        var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecorder);
+	        var navigationMock = new Mock<INavigation>();
+	        var navigator = new Navigator(contentPageMock1, navigationMock.Object);
+	        var behaviorInjectorMock = new Mock<IBehaviorInjector>();
+	        navigator.BehaviorInjector = behaviorInjectorMock.Object;
+
+	        var contentPageMock2 = new ContentPageMock(eventRecorder);
+	        await navigator.PushAsync(contentPageMock2, false);
+
+
+	        behaviorInjectorMock.Verify(x => x.Inject(contentPageMock2), Times.Once);
+	        navigationMock.Verify(x => x.PushAsync(contentPageMock2, false), Times.Once);
+	    }
+
+		[Fact]
+		public async Task PushAsync_WithParameter()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder);
+		    // ReSharper disable once UnusedVariable
+			var navigationPageMock = new NavigationPageMock(contentPageMock1, eventRecorder);
+			var navigationMock = new Mock<INavigation>();
+			var navigator = new Navigator(contentPageMock1, navigationMock.Object);
+			var behaviorInjectorMock = new Mock<IBehaviorInjector>();
+			navigator.BehaviorInjector = behaviorInjectorMock.Object;
+
+			var contentPageMock2 = new ContentPageMock(eventRecorder);
+			var parameter = new object();
+			await navigator.PushAsync(contentPageMock2, parameter);
+
+
+			behaviorInjectorMock.Verify(x => x.Inject(contentPageMock2), Times.Once);
+			navigationMock.Verify(x => x.PushAsync(contentPageMock2, true), Times.Once);
+
+			Assert.Equal(3, eventRecorder.Count);
+
+			Assert.Equal(contentPageMock2, eventRecorder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecorder[0].CallerMemberName);
+			Assert.Equal(parameter, eventRecorder[0].Parameter);
+
+			Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+			Assert.Equal("OnLoaded", eventRecorder[1].CallerMemberName);
+			Assert.Null(eventRecorder[1].Parameter);
+
+			Assert.Equal(contentPageMock1, eventRecorder[2].Sender);
+			Assert.Equal("OnUnloaded", eventRecorder[2].CallerMemberName);
+			Assert.Null(eventRecorder[2].Parameter);
+		}
+
+		[Fact]
+		public async Task PushModalAsync()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder);
+			var navigationMock = new Mock<INavigation>();
+			var navigator = new Navigator(contentPageMock1, navigationMock.Object);
+			var behaviorInjectorMock = new Mock<IBehaviorInjector>();
+			navigator.BehaviorInjector = behaviorInjectorMock.Object;
+
+			var contentPageMock2 = new ContentPageMock(eventRecorder);
+			await navigator.PushModalAsync(contentPageMock2);
+
+
+			behaviorInjectorMock.Verify(x => x.Inject(contentPageMock2), Times.Once);
+			navigationMock.Verify(x => x.PushModalAsync(contentPageMock2, true), Times.Once);
+
+			Assert.Equal(3, eventRecorder.Count);
+
+			Assert.Equal(contentPageMock2, eventRecorder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecorder[0].CallerMemberName);
+			Assert.Null(eventRecorder[0].Parameter);
+
+			Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+			Assert.Equal("OnLoaded", eventRecorder[1].CallerMemberName);
+			Assert.Null(eventRecorder[1].Parameter);
+
+			Assert.Equal(contentPageMock1, eventRecorder[2].Sender);
+			Assert.Equal("OnUnloaded", eventRecorder[2].CallerMemberName);
+			Assert.Null(eventRecorder[2].Parameter);
+		}
+
+	    [Fact]
+	    public async Task PushModalAsync_WhenAnimatedIsFalse()
+	    {
+	        var eventRecorder = new EventRecorder();
+	        var contentPageMock1 = new ContentPageMock(eventRecorder);
+	        var navigationMock = new Mock<INavigation>();
+	        var navigator = new Navigator(contentPageMock1, navigationMock.Object);
+	        var behaviorInjectorMock = new Mock<IBehaviorInjector>();
+	        navigator.BehaviorInjector = behaviorInjectorMock.Object;
+
+	        var contentPageMock2 = new ContentPageMock(eventRecorder);
+	        await navigator.PushModalAsync(contentPageMock2, false);
+
+
+	        behaviorInjectorMock.Verify(x => x.Inject(contentPageMock2), Times.Once);
+	        navigationMock.Verify(x => x.PushModalAsync(contentPageMock2, false), Times.Once);
+	    }
+
+		[Fact]
+		public async Task PushModalAsync_WithParameter()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder);
+			var navigationMock = new Mock<INavigation>();
+			var navigator = new Navigator(contentPageMock1, navigationMock.Object);
+			var behaviorInjectorMock = new Mock<IBehaviorInjector>();
+			navigator.BehaviorInjector = behaviorInjectorMock.Object;
+
+			var contentPageMock2 = new ContentPageMock(eventRecorder);
+			var parameter = new object();
+			await navigator.PushModalAsync(contentPageMock2, parameter);
+
+
+			behaviorInjectorMock.Verify(x => x.Inject(contentPageMock2), Times.Once);
+			navigationMock.Verify(x => x.PushModalAsync(contentPageMock2, true), Times.Once);
+
+			Assert.Equal(3, eventRecorder.Count);
+
+			Assert.Equal(contentPageMock2, eventRecorder[0].Sender);
+			Assert.Equal("OnInitialize", eventRecorder[0].CallerMemberName);
+			Assert.Equal(parameter, eventRecorder[0].Parameter);
+
+			Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+			Assert.Equal("OnLoaded", eventRecorder[1].CallerMemberName);
+			Assert.Null(eventRecorder[1].Parameter);
+
+			Assert.Equal(contentPageMock1, eventRecorder[2].Sender);
+			Assert.Equal("OnUnloaded", eventRecorder[2].CallerMemberName);
+			Assert.Null(eventRecorder[2].Parameter);
+		}
+
+		[Fact]
+		public void RemovePage_LastPage()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder);
+			var navigationPage = new NavigationPage(contentPageMock1);
+			navigationPage.Behaviors.Add(new NavigationPageBehavior());
+			var contentPageMock2 = new ContentPageMock(eventRecorder);
+			contentPageMock1.Navigation.PushAsync(contentPageMock2);
+			
+			var navigator= new Navigator(contentPageMock2);
+			navigator.RemovePage(contentPageMock2);
+			
+			Assert.Equal(contentPageMock1, navigationPage.CurrentPage);
+			
+			Assert.Equal(2, eventRecorder.Count);
+
+			Assert.Equal(contentPageMock1, eventRecorder[0].Sender);
+			Assert.Equal("OnLoaded", eventRecorder[0].CallerMemberName);
+			Assert.Null(eventRecorder[0].Parameter);
+
+			Assert.Equal(contentPageMock2, eventRecorder[1].Sender);
+			Assert.Equal("OnClosed", eventRecorder[1].CallerMemberName);
+			Assert.Null(eventRecorder[1].Parameter);
+		}
+
+		[Fact]
+		public void RemovePage_NotLastPage()
+		{
+			var eventRecorder = new EventRecorder();
+			var contentPageMock1 = new ContentPageMock(eventRecorder);
+			var navigationPage = new NavigationPage(contentPageMock1);
+			navigationPage.Behaviors.Add(new NavigationPageBehavior());
+			var contentPageMock2 = new ContentPageMock(eventRecorder);
+			contentPageMock1.Navigation.PushAsync(contentPageMock2);
+
+			var navigator = new Navigator(contentPageMock2);
+			navigator.RemovePage(contentPageMock1);
+
+			Assert.Equal(contentPageMock2, navigationPage.CurrentPage);
+
+			Assert.Equal(1, eventRecorder.Count);
+
+			Assert.Equal(contentPageMock1, eventRecorder[0].Sender);
+			Assert.Equal("OnClosed", eventRecorder[0].CallerMemberName);
+			Assert.Null(eventRecorder[0].Parameter);
+		}
+
+	}
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/PageExtensionsFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/PageExtensionsFixture.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Platform;
+using Xunit;
+
+namespace Kamishibai.Maui.Tests
+{
+	public class PageExtensionsFixture
+	{
+		[Fact]
+		public void GetParentPage()
+		{
+			var contentPage = new ContentPage();
+			var navigationPage = new NavigationPage(contentPage);
+			
+			Assert.Equal(navigationPage, contentPage.GetParentPage());
+		}
+
+		[Fact]
+		public void GetParentPage_WhenParentIsNull()
+		{
+			var contentPage = new ContentPage();
+
+			Assert.Null(contentPage.GetParentPage());
+		}
+
+	    [Fact]
+	    public void GetParentPage_WhenPageIsNull()
+	    {
+	        Assert.Null(PageExtensions.GetParentPage(null));
+	    }
+
+        [Fact]
+		public void GetParentPage_WithTypeParameter()
+		{
+			var contentPage = new ContentPage();
+			var navigationPage = new NavigationPage(contentPage);
+
+			Assert.Equal(navigationPage, contentPage.GetParentPage<NavigationPage>());
+
+		}
+
+		[Fact]
+		public void GetParentPage_WithTypeParameter_WhenIncludeCurrent()
+		{
+			var contentPage = new ContentPage();
+
+			Assert.Equal(contentPage, contentPage.GetParentPage<ContentPage>(true));
+
+		    var navigationPage = new NavigationPage(contentPage);
+
+		    Assert.Equal(navigationPage, contentPage.GetParentPage<NavigationPage>(true));
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui.Tests/TestFixture.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/TestFixture.cs
@@ -1,0 +1,13 @@
+﻿using Kamishibai.Maui.Tests.Mocks;
+
+namespace Kamishibai.Maui.Tests
+{
+	public abstract class TestFixture
+	{
+		protected TestFixture()
+		{
+			Microsoft.Maui.Dispatching.DispatcherProvider.SetCurrent(new DispatcherProviderStub());
+		}
+	}
+}
+

--- a/MAUI/Source/Kamishibai.Maui.Tests/Usings.cs
+++ b/MAUI/Source/Kamishibai.Maui.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/MAUI/Source/Kamishibai.Maui.sln
+++ b/MAUI/Source/Kamishibai.Maui.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32427.441
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kamishibai.Maui", "Kamishibai.Maui\Kamishibai.Maui.csproj", "{49F7E542-39C7-4DC4-9850-D64C9630FDF4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kamishibai.Maui.Tests", "Kamishibai.Maui.Tests\Kamishibai.Maui.Tests.csproj", "{196D3B31-AEB4-41F8-A14A-A6FCE07F197D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{49F7E542-39C7-4DC4-9850-D64C9630FDF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49F7E542-39C7-4DC4-9850-D64C9630FDF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49F7E542-39C7-4DC4-9850-D64C9630FDF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49F7E542-39C7-4DC4-9850-D64C9630FDF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{196D3B31-AEB4-41F8-A14A-A6FCE07F197D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{196D3B31-AEB4-41F8-A14A-A6FCE07F197D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{196D3B31-AEB4-41F8-A14A-A6FCE07F197D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{196D3B31-AEB4-41F8-A14A-A6FCE07F197D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {40D533CD-8191-460A-8156-415FABD11AC3}
+	EndGlobalSection
+EndGlobal

--- a/MAUI/Source/Kamishibai.Maui/ApplicationService.cs
+++ b/MAUI/Source/Kamishibai.Maui/ApplicationService.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Maui.Controls;
+
+
+namespace Kamishibai.Maui
+{
+    public static class ApplicationService
+    {
+        private static IApplication _current;
+
+        internal static IApplication Current
+        {
+            get => _current;
+            set
+            {
+                if (_current != null)
+                    _current.ModalPopped -= OnModalPopped;
+
+                _current = value;
+                _current.ModalPopped += OnModalPopped;
+            }
+        }
+
+        internal static IBehaviorInjector BehaviorInjector { get; set; } = new BehaviorInjector();
+        
+        public  static void Initialize(Application application)
+        {
+            Current = new ApplicationAdapter(application);
+        }
+
+        public static void SetMainPage(Page page)
+        {
+            SetMainPage<object>(page);
+        }
+        
+        public static void SetMainPage<T>(Page page, T parameter = default(T))
+        {
+			BehaviorInjector.Inject(page);
+
+            page.OnInitialize(parameter);
+            Current.MainPage = page;
+            page.OnLoaded();
+        }
+
+        private static void OnModalPopped(object sender, ModalPoppedEventArgs e)
+        {
+            var currentPage = Current.MainPage.Navigation.ModalStack.Last();
+            currentPage.OnLoaded();
+            e.Modal.OnClosed();
+        }
+        
+        internal interface IApplication
+        {
+            event EventHandler<ModalPoppedEventArgs> ModalPopped;
+            Page MainPage { get; set; }
+        }
+
+        internal class ApplicationAdapter : IApplication
+        {
+            private readonly Application _currentApplication;
+
+            Page IApplication.MainPage
+            {
+                get => _currentApplication.MainPage;
+                set => _currentApplication.MainPage = value;
+            }
+
+            public event EventHandler<ModalPoppedEventArgs> ModalPopped;
+            public ApplicationAdapter(Application currentApplication)
+            {
+                if(currentApplication == null) return;
+
+                _currentApplication = currentApplication;
+                _currentApplication.ModalPopped += (sender, args) => ModalPopped?.Invoke(sender, args);
+            }
+        }
+        
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/BehaviorBase.cs
+++ b/MAUI/Source/Kamishibai.Maui/BehaviorBase.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public abstract class BehaviorBase<T> : Behavior<T> where T : BindableObject
+    {
+        private bool _inheritedBindingContedt;
+
+		protected T AssociatedObject { get; private set; }
+
+        protected override void OnAttachedTo(T bindableObject)
+        {
+            base.OnAttachedTo(bindableObject);
+
+            AssociatedObject = bindableObject;
+	        InheritBindingContext(bindableObject);
+
+			bindableObject.BindingContextChanged += OnBindingContextChanged;
+        }
+
+        private void OnBindingContextChanged(object sender, EventArgs e)
+        {
+	        InheritBindingContext(AssociatedObject);
+        }
+
+		private void InheritBindingContext(T bindableObject)
+	    {
+		    if (BindingContext == null || _inheritedBindingContedt)
+		    {
+			    BindingContext = bindableObject.BindingContext;
+			    _inheritedBindingContedt = true;
+		    }
+		}
+
+		protected override void OnDetachingFrom(T bindableObject)
+        {
+            BindingContext = null;
+            bindableObject.BindingContextChanged -= OnBindingContextChanged;
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/BehaviorInjector.cs
+++ b/MAUI/Source/Kamishibai.Maui/BehaviorInjector.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public class BehaviorInjector : IBehaviorInjector
+    {
+        public void Inject(Page page)
+        {
+            if (page is NavigationPage navigationPage)
+            {
+                InjectionBehavior<NavigationPageBehavior>(page);
+                Injects(navigationPage.Navigation.NavigationStack);
+            }
+            else if (page is TabbedPage tabbedPage)
+            {
+                InjectionBehavior<MultiPageBehavior<Page>>(page);
+                Injects(tabbedPage.Children);
+            }
+        }
+
+        private void Injects(IEnumerable<Page> pages)
+        {
+            foreach (var page in pages)
+            {
+                Inject(page);
+            }
+        }
+
+        private static void InjectionBehavior<TBehavior>(Page page) where TBehavior : Behavior
+        {
+            foreach (var behavior in page.Behaviors)
+            {
+                if (behavior is TBehavior)
+                {
+                    return;
+                }
+            }
+            page.Behaviors.Add(Activator.CreateInstance<TBehavior>());
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IApplicationLifecycleAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IApplicationLifecycleAware.cs
@@ -1,0 +1,6 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IApplicationLifecycleAware : IApplicationOnResumeAware, IApplicationOnSleepAware
+    {
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IApplicationOnResumeAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IApplicationOnResumeAware.cs
@@ -1,0 +1,7 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IApplicationOnResumeAware
+    {
+        void OnResume();
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IApplicationOnSleepAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IApplicationOnSleepAware.cs
@@ -1,0 +1,7 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IApplicationOnSleepAware
+    {
+        void OnSleep();
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IBehaviorInjector.cs
+++ b/MAUI/Source/Kamishibai.Maui/IBehaviorInjector.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public interface IBehaviorInjector
+    {
+        void Inject(Page page);
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/ILifecycleNotifier.cs
+++ b/MAUI/Source/Kamishibai.Maui/ILifecycleNotifier.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public interface ILifecycleNotifier<in TParam>
+    {
+        void Notify(Page page, TParam parameter);
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/INavigator.cs
+++ b/MAUI/Source/Kamishibai.Maui/INavigator.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public interface INavigator
+    {
+        IReadOnlyList<Page> ModalStack { get; }
+        IReadOnlyList<Page> NavigationStack { get; }
+        void InsertPageBefore(Page page, Page before);
+        void InsertPageBefore<TParam>(Page page, Page before, TParam parameter = default(TParam));
+        Task<Page> PopAsync(bool animated = true);
+        Task<Page> PopModalAsync(bool animated = true);
+        Task PopToRootAsync(bool animated = true);
+        Task PushAsync(Page page, bool animated = true);
+        Task PushAsync<TParam>(Page page, TParam parameter = default(TParam), bool animated = true);
+        Task PushModalAsync(Page page, bool animated = true);
+        Task PushModalAsync<TParam>(Page page, TParam parameter = default(TParam), bool animated = true);
+        void RemovePage(Page page);
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IPageClosedAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IPageClosedAware.cs
@@ -1,0 +1,7 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IPageClosedAware
+    {
+        void OnClosed();
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IPageInitializeAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IPageInitializeAware.cs
@@ -1,0 +1,12 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IPageInitializeAware<in TParam>
+    {
+        void OnInitialize(TParam parameter);
+    }
+
+    public interface IPageInitializeAware
+    {
+        void OnInitialize();
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IPageLifecycleAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IPageLifecycleAware.cs
@@ -1,0 +1,11 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IPageLifecycleAware<in TParam>: IPageInitializeAware<TParam>, IPageLoadedAware, IPageUnloadedAware, IPageClosedAware
+    {
+    }
+    
+    public interface IPageLifecycleAware: IPageInitializeAware, IPageLoadedAware, IPageUnloadedAware, IPageClosedAware
+    {
+    }
+
+}

--- a/MAUI/Source/Kamishibai.Maui/IPageLoadedAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IPageLoadedAware.cs
@@ -1,0 +1,7 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IPageLoadedAware
+    {
+        void OnLoaded();
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/IPageUnloadedAware.cs
+++ b/MAUI/Source/Kamishibai.Maui/IPageUnloadedAware.cs
@@ -1,0 +1,7 @@
+﻿namespace Kamishibai.Maui
+{
+    public interface IPageUnloadedAware
+    {
+        void OnUnloaded();
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Kamishibai.Maui.csproj
+++ b/MAUI/Source/Kamishibai.Maui/Kamishibai.Maui.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<UseMaui>true</UseMaui>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+		<DebugType>full</DebugType>
+		<RootNamespace>Kamishibai.Maui</RootNamespace>
+		<AssemblyName>Kamishibai.Maui</AssemblyName>
+		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+		<Authors>nuits.jp</Authors>
+		<Company>nuits.jp</Company>
+		<Title>KAMISHIBAI for MAUI</Title>
+		<Product>Kamishibai.Maui</Product>
+		<Copyright>Copyright 2017 nuits.jp</Copyright>
+		<PackageLicenseUrl>https://github.com/nuitsjp/KAMISHIBAI/blob/master/LICENSE</PackageLicenseUrl>
+		<PackageProjectUrl>https://github.com/nuitsjp/KAMISHIBAI</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/nuitsjp/KAMISHIBAI</RepositoryUrl>
+		<RepositoryType>GitHub</RepositoryType>
+		<PackageTags>Xamarin MAUI Navigation Maui.Controls.Navigation Kamishibai Kamishibai.Maui</PackageTags>
+		<Description>KAMISHIBAI for MAUI is the most flexible page navigation framework. KAMISHIBAI for MAUI supports MVVM Pattern.</Description>
+		<Summary>KAMISHIBAI for MAUI is the most flexible page navigation framework. KAMISHIBAI for MAUI supports MVVM Pattern.</Summary>
+		<AssemblyVersion>1.1.0.0</AssemblyVersion>
+		<FileVersion>1.1.0.0</FileVersion>
+		<Version>1.1.0</Version>
+	</PropertyGroup>
+
+</Project>

--- a/MAUI/Source/Kamishibai.Maui/LifecycleNoticeService.cs
+++ b/MAUI/Source/Kamishibai.Maui/LifecycleNoticeService.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public static class LifecycleNoticeService
+    {
+        public static void OnInitialize(this Page page)
+        {
+            page.Notify<IPageInitializeAware, object>((target, param) => target.OnInitialize());
+        }
+        public static void OnInitialize<TParam>(this Page page, TParam parameter)
+        {
+            page.Notify<IPageInitializeAware<TParam>, TParam>((target, param) => target.OnInitialize(param), parameter);
+        }
+        public static void OnLoaded(this Page page)
+        {
+            page.Notify<IPageLoadedAware, object>((target, param) => target.OnLoaded());
+        }
+
+        public static void OnUnloaded(this Page page)
+        {
+            page.Notify<IPageUnloadedAware, object>((target, param) => target.OnUnloaded());
+        }
+
+        public static void OnClosed(this Page page)
+        {
+            page.Notify<IPageClosedAware, object>((target, param) => target.OnClosed());
+        }
+
+        public static void OnResume(Application application)
+        {
+            var notifier =
+                new LifecycleNotifier<IApplicationOnResumeAware, object>((target, param) => target.OnResume());
+            notifier.Notify(application.MainPage);
+            foreach (var page in application.MainPage.Navigation.ModalStack)
+            {
+                notifier.Notify(page);
+            }
+        }
+
+        public static void OnSleep(Application application)
+        {
+            var notifier =
+                new LifecycleNotifier<IApplicationOnSleepAware, object>((target, param) => target.OnSleep());
+            foreach (var page in application.MainPage.Navigation.ModalStack.Reverse())
+            {
+                notifier.Notify(page);
+            }
+            notifier.Notify(application.MainPage);
+        }
+
+        private static void Notify<TTarget, TParam>(this Page page, Action<TTarget, TParam> action, TParam param = default(TParam)) where TTarget : class
+        {
+            new LifecycleNotifier<TTarget, TParam>(action).Notify(page, param);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/LifecycleNotifier.cs
+++ b/MAUI/Source/Kamishibai.Maui/LifecycleNotifier.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public class LifecycleNotifier<TTarget, TParam> : ILifecycleNotifier<TParam> where TTarget : class 
+    {
+        private readonly Action<TTarget, TParam> _action;
+
+        private static bool IsTopDown => !(typeof(TTarget) == typeof(IPageUnloadedAware)
+                                           || typeof(TTarget) == typeof(IPageClosedAware)
+                                           || typeof(TTarget) == typeof(IApplicationOnSleepAware));
+
+        public LifecycleNotifier(Action<TTarget, TParam> action)
+        {
+            _action = action;
+        }
+
+        public void Notify(Page page, TParam param = default(TParam))
+        {
+            if (IsTopDown)
+            {
+                NotifyToPage(page, param);
+                NotifyToViewModel(page, param);
+                
+                Visit(page, param);
+            }
+            else
+            {
+                Visit(page, param);
+                
+                NotifyToViewModel(page, param);
+                NotifyToPage(page, param);
+            }
+        }
+
+        private void NotifyToPage(Page page, TParam param)
+        {
+            var pageAsT = page as TTarget;
+            if (pageAsT != null)
+            {
+                _action(pageAsT, param);
+            }
+        }
+
+        private void NotifyToViewModel(Page page, TParam param)
+        {
+            var parent = page.GetParentPage();
+            if (parent?.BindingContext != page.BindingContext)
+            {
+                var viewModelAsT = page.BindingContext as TTarget;
+                if (viewModelAsT != null)
+                {
+                    _action(viewModelAsT, param);
+                }
+            }
+        }
+
+        public void Visit(Page page, TParam param)
+        {
+            if (page is NavigationPage navigationPage)
+            {
+                Visit(navigationPage, param);
+            }
+            else if (page is FlyoutPage FlyoutPage)
+            {
+                Visit(FlyoutPage, param);
+            }
+            else if (page is TabbedPage tabbedPage)
+            {
+                Visit(tabbedPage, param);
+            }
+        }
+
+        private void Visit(NavigationPage page, TParam param)
+        {
+            if (typeof(TTarget) == typeof(IPageLoadedAware)
+                || typeof(TTarget) == typeof(IPageUnloadedAware))
+            {
+                Notify(page.CurrentPage, param);
+            }
+            else if (typeof(TTarget) == typeof(IPageClosedAware)
+                || typeof(TTarget) == typeof(IApplicationOnSleepAware))
+            {
+                foreach (var child in page.Navigation.NavigationStack.Reverse())
+                {
+                    Notify(child, param);
+                }
+            }
+            else
+            {
+                foreach (var child in page.Navigation.NavigationStack)
+                {
+                    Notify(child, param);
+                }
+            }
+        }
+
+        private void Visit(FlyoutPage page, TParam param)
+        {
+            if (IsTopDown)
+            {
+                Notify(page.Flyout, param);
+                Notify(page.Detail, param);
+            }
+            else
+            {
+                Notify(page.Detail, param);
+                Notify(page.Flyout, param);
+            }
+        }
+
+        private void Visit(TabbedPage page, TParam param)
+        {
+            if (typeof(TTarget) == typeof(IPageLoadedAware)
+                || typeof(TTarget) == typeof(IPageUnloadedAware))
+            {
+                Notify(page.CurrentPage, param);
+            }
+            else if (typeof(TTarget) == typeof(IPageClosedAware)
+                     || typeof(TTarget) == typeof(IApplicationOnSleepAware))
+            {
+                foreach (var pageChild in page.Children.Reverse())
+                {
+                    Notify(pageChild, param);
+                }
+            }
+            else
+            {
+                foreach (var pageChild in page.Children)
+                {
+                    Notify(pageChild, param);
+                }
+            }
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/MultiPageBehavior.cs
+++ b/MAUI/Source/Kamishibai.Maui/MultiPageBehavior.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Specialized;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public class MultiPageBehavior<TPage> : BehaviorBase<MultiPage<TPage>> where TPage : Page
+    {
+        protected TPage PreviousPage { get; set; }
+        protected override void OnAttachedTo(MultiPage<TPage> bindableObject)
+        {
+            base.OnAttachedTo(bindableObject);
+            PreviousPage = AssociatedObject.CurrentPage;
+            AssociatedObject.CurrentPageChanged += OnCurrentPageChanged;
+            AssociatedObject.PagesChanged += OnPagesChanged;
+        }
+
+        protected override void OnDetachingFrom(MultiPage<TPage> bindableObject)
+        {
+            AssociatedObject.PagesChanged -= OnPagesChanged;
+            AssociatedObject.CurrentPageChanged -= OnCurrentPageChanged;
+            base.OnDetachingFrom(bindableObject);
+        }
+
+        private void OnCurrentPageChanged(object sender, EventArgs eventArgs)
+        {
+            AssociatedObject.CurrentPage?.OnLoaded();
+            PreviousPage?.OnUnloaded();
+            PreviousPage = AssociatedObject.CurrentPage;
+        }
+
+        private void OnPagesChanged(object sender, NotifyCollectionChangedEventArgs eventArgs)
+        {
+	        if (eventArgs.NewItems != null)
+	        {
+		        foreach (var newItem in eventArgs.NewItems)
+		        {
+			        ((Page)newItem).OnInitialize((object)null);
+		        }
+	        }
+            if (eventArgs.OldItems != null)
+            {
+	            foreach (var oldItem in eventArgs.OldItems)
+	            {
+		            ((Page)oldItem).OnClosed();
+	            }
+            }
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/AnimatableNavigation.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/AnimatableNavigation.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="TPage"></typeparam>
+	public abstract class AnimatableNavigation<TPage> : NavigationBehavior<TPage> where TPage : Page
+    {
+        public static readonly BindableProperty AnimatedProperty =
+            BindableProperty.Create(nameof(Animated), typeof(bool), typeof(AnimatableNavigation<TPage>), true);
+
+        public bool Animated
+        {
+            get => (bool)GetValue(AnimatedProperty);
+            set => SetValue(AnimatedProperty, value);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/INavigationAction.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/INavigationAction.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public interface INavigationAction
+    {
+        Task Navigate<TParam>(TParam parameter = default(TParam));
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/INavigationRequest.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/INavigationRequest.cs
@@ -1,0 +1,17 @@
+﻿using System.Threading.Tasks;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public interface INavigationRequest
+    {
+        INavigationAction NavigationAction { set; }
+
+        Task RaiseAsync();
+    }
+
+    public interface INavigationRequest<in TParam> : INavigationRequest
+    {
+        Task RaiseAsync(TParam param);
+    }
+
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/InsertPageBefore.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/InsertPageBefore.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class InsertPageBefore<TPage, TBefore> : NavigationBehavior<TPage> 
+        where TPage : Page
+        where TBefore : Page
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            var beforePage = CurrentPage.Navigation.NavigationStack.FirstOrDefault(x => x.GetType() == typeof(TBefore));
+            Navigator.InsertPageBefore(ServiceLocator.GetInstance<TPage>(), beforePage, parameter);
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/NavigationBehavior.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/NavigationBehavior.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public abstract class NavigationBehavior<TPage> : BehaviorBase<Page>, INavigationAction where TPage : Page
+    {
+        public static readonly BindableProperty RequestProperty =
+            BindableProperty.Create(
+                nameof(Request),
+                typeof(INavigationRequest),
+                typeof(NavigationBehavior<TPage>),
+                propertyChanged: NavigationRequestPropertyChanged);
+
+	    private INavigator _navigator;
+
+	    public INavigationRequest Request
+        {
+            get => (INavigationRequest)GetValue(RequestProperty);
+            set => SetValue(RequestProperty, value);
+        }
+
+	    public INavigator Navigator
+	    {
+		    get => _navigator ?? (_navigator = new Navigator(AssociatedObject));
+		    set => _navigator = value;
+	    }
+
+	    public Page CurrentPage => AssociatedObject;
+
+        private static void NavigationRequestPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (newValue != null)
+            {
+                var navigationAction = (NavigationBehavior<TPage>)bindable;
+                ((INavigationRequest)newValue).NavigationAction = navigationAction;
+            }
+            if (oldValue != null)
+            {
+                ((INavigationRequest)oldValue).NavigationAction = null;
+            }
+        }
+
+        public abstract Task Navigate<T>(T parameter = default(T));
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/NavigationRequest.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/NavigationRequest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class NavigationRequest<TParam> : INavigationRequest<TParam>
+    {
+        private INavigationAction _navigationAction;
+
+	    public INavigationAction NavigationAction
+	    {
+		    set => _navigationAction = value;
+	    }
+
+        Task INavigationRequest.RaiseAsync()
+        {
+            return RaiseAsync(default(TParam));
+        }
+
+        public Task RaiseAsync(TParam parameter)
+        {
+            if (_navigationAction == null) throw new InvalidOperationException("NavigationAction is null");
+            return _navigationAction.Navigate(parameter);
+        }
+    }
+
+    public class NavigationRequest : INavigationRequest
+    {
+        private INavigationAction _navigationAction;
+
+        public INavigationAction NavigationAction
+        {
+            set => _navigationAction = value;
+        }
+
+        public Task RaiseAsync()
+        {
+            if(_navigationAction == null) throw new InvalidOperationException("NavigationAction is null");
+            return _navigationAction.Navigate<object>();
+        }
+    }
+
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/NavigationRequestCommand.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/NavigationRequestCommand.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class NavigationRequestCommand<TParam> : NavigationRequest<TParam>, ICommand
+    {
+        private readonly Action<TParam> _execute;
+        private readonly Func<TParam, bool> _canExecute;
+
+        public event EventHandler CanExecuteChanged;
+
+        public NavigationRequestCommand() : this(_ => { }, _ => true)
+        {
+        }
+
+        public NavigationRequestCommand(Action execute)
+        {
+            if(execute == null) throw new ArgumentNullException(nameof(execute));
+
+            _execute = _ => execute();
+            _canExecute = _ => true;
+        }
+
+        public NavigationRequestCommand(Action execute, Func<bool> canExecute)
+        {
+            if (execute == null) throw new ArgumentNullException(nameof(execute));
+            if (canExecute == null) throw new ArgumentNullException(nameof(canExecute));
+
+            _execute = _ => execute();
+            _canExecute = _ => canExecute();
+        }
+
+        public NavigationRequestCommand(Action<TParam> execute) : this(execute, _ => true)
+        {
+        }
+
+        public NavigationRequestCommand(Action<TParam> execute, Func<TParam, bool> canExecute)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
+        }
+
+        public bool CanExecute(TParam parameter = default(TParam))
+        {
+            return _canExecute(parameter);
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            if (parameter is TParam)
+            {
+                return CanExecute((TParam) parameter);
+            }
+            else
+            {
+                return CanExecute();
+            }
+        }
+
+        public void Execute(TParam parameter = default(TParam))
+        {
+            _execute(parameter);
+            RaiseAsync(parameter);
+        }
+
+        public void Execute(object parameter)
+        {
+            if (parameter is TParam)
+            {
+                Execute((TParam)parameter);
+            }
+            else
+            {
+                Execute();
+            }
+        }
+
+        public void ChangeCanExecute()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+    
+    public class NavigationRequestCommand : NavigationRequest, ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool> _canExecute;
+
+        public event EventHandler CanExecuteChanged;
+
+        public NavigationRequestCommand() : this(() => { }, () => true)
+        {
+        }
+
+        public NavigationRequestCommand(Action execute) : this(execute, () => true)
+        {
+        }
+        public NavigationRequestCommand(Action execute, Func<bool> canExecute)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute ?? throw new ArgumentNullException(nameof(canExecute));
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute();
+        }
+
+        public void Execute(object parameter)
+        {
+            _execute();
+            RaiseAsync();
+        }
+
+        public void ChangeCanExecute()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/PopAsync.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/PopAsync.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class PopAsync : AnimatableNavigation<Page>
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            return Navigator.PopAsync(Animated);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/PopModalAsync.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/PopModalAsync.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class PopModalAsync : AnimatableNavigation<Page>
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            return Navigator.PopModalAsync(Animated);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/PopToRootAsync.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/PopToRootAsync.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class PopToRootAsync : AnimatableNavigation<Page>
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            return Navigator.PopToRootAsync(Animated);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/PushAsync.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/PushAsync.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class PushAsync<TPage> : AnimatableNavigation<TPage> where TPage : Page
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            return Navigator.PushAsync(ServiceLocator.GetInstance<TPage>(), parameter, Animated);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/PushModalAsync.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/PushModalAsync.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class PushModalAsync<TPage> : AnimatableNavigation<TPage> where TPage : Page
+    {
+        public static readonly BindableProperty WithNavigationPageProperty =
+            BindableProperty.Create(nameof(WithNavigationPage), typeof(bool), typeof(PushModalAsync<TPage>), false);
+
+        public bool WithNavigationPage
+        {
+            get => (bool)GetValue(WithNavigationPageProperty);
+            set => SetValue(WithNavigationPageProperty, value);
+        }
+        
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            if (WithNavigationPage)
+            {
+                return Navigator.PushModalAsync(new NavigationPage(ServiceLocator.GetInstance<TPage>()), parameter, Animated);
+            }
+            else
+            {
+                return Navigator.PushModalAsync(ServiceLocator.GetInstance<TPage>(), parameter, Animated);
+            }
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/RemovePage.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/RemovePage.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class RemovePage<TPage> : NavigationBehavior<TPage> where TPage : Page
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            var target = CurrentPage.Navigation.NavigationStack.FirstOrDefault(x => x.GetType() == typeof(TPage));
+            if (target != null)
+            {
+                Navigator.RemovePage(target);
+            }
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/ServiceLocator.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/ServiceLocator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public static class ServiceLocator
+    {
+        public static readonly Func<Type, object> DefaultLocator = type => Activator.CreateInstance(type);
+
+        private static Func<Type, object> _locator = DefaultLocator;
+
+        public static T GetInstance<T>()
+        {
+            return (T) _locator(typeof(T));
+        }
+
+        public static void SetLocator(Func<Type, object> resolver)
+        {
+            _locator = resolver;
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Mvvm/SetMainPage.cs
+++ b/MAUI/Source/Kamishibai.Maui/Mvvm/SetMainPage.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui.Mvvm
+{
+    public class SetMainPage<TPage> : NavigationBehavior<TPage> where TPage : Page
+    {
+        public override Task Navigate<TParam>(TParam parameter = default(TParam))
+        {
+            ApplicationService.SetMainPage(ServiceLocator.GetInstance<TPage>(), parameter);
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/NavigationPageBehavior.cs
+++ b/MAUI/Source/Kamishibai.Maui/NavigationPageBehavior.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public class NavigationPageBehavior : BehaviorBase<NavigationPage>
+    {
+        protected override void OnAttachedTo(NavigationPage navigationPage)
+        {
+            base.OnAttachedTo(navigationPage);
+            navigationPage.Popped += OnPopped;
+        }
+
+        protected override void OnDetachingFrom(NavigationPage navigationPage)
+        {
+            navigationPage.Popped -= OnPopped;
+            base.OnDetachingFrom(navigationPage);
+        }
+
+        private void OnPopped(object sender, NavigationEventArgs navigationEventArgs)
+        {
+            AssociatedObject.CurrentPage.OnLoaded();
+            navigationEventArgs.Page.OnClosed();
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Navigator.cs
+++ b/MAUI/Source/Kamishibai.Maui/Navigator.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public class Navigator : INavigator
+    {
+        private readonly Page _currentPage;
+
+        private INavigation Navigation { get; }
+        
+        internal IBehaviorInjector BehaviorInjector { get; set; } = new BehaviorInjector();
+
+        public IReadOnlyList<Page> ModalStack => Navigation.ModalStack;
+        public IReadOnlyList<Page> NavigationStack => Navigation.NavigationStack;
+
+        public Navigator(Page page) : this(page, page.Navigation)
+        {
+        }
+
+	    internal Navigator(Page page, INavigation navigation)
+	    {
+		    _currentPage = page;
+		    Navigation = navigation;
+	    }
+
+		public void InsertPageBefore(Page page, Page before)
+        {
+            InsertPageBefore<object>(page, before);
+        }
+
+        public void InsertPageBefore<TParam>(Page page, Page before, TParam parameter = default(TParam))
+        {
+            page.OnInitialize(parameter);
+            Navigation.InsertPageBefore(page, before);
+        }
+        public Task<Page> PopAsync(bool animated = true)
+        {
+            return Navigation.PopAsync(animated);
+        }
+
+        public Task<Page> PopModalAsync(bool animated = true)
+        {
+            return Navigation.PopModalAsync(animated);
+        }
+
+        public async Task PopToRootAsync(bool animated = true)
+        {
+            var navigationPage = _currentPage.Parent as NavigationPage;
+            if (navigationPage != null)
+            {
+                var pages = _currentPage.Navigation.NavigationStack.ToList();
+
+                await Navigation.PopToRootAsync(animated);
+
+                navigationPage.CurrentPage.OnLoaded();
+                pages.RemoveAt(0);
+                pages.Reverse();
+                foreach (var page in pages)
+                {
+                    page.OnClosed();
+                }
+            }
+        }
+
+        public async Task PushAsync(Page page, bool animated = true)
+        {
+            page.OnInitialize();
+
+            BehaviorInjector.Inject(page);
+            await Navigation.PushAsync(page, animated);
+
+            page.OnLoaded();
+            _currentPage.OnUnloaded();
+        }
+        
+        public async Task PushAsync<TParam>(Page page, TParam parameter = default(TParam), bool animated = true)
+        {
+            page.OnInitialize(parameter);
+
+            BehaviorInjector.Inject(page);
+            await Navigation.PushAsync(page, animated);
+            
+            page.OnLoaded();
+            _currentPage.OnUnloaded();
+        }
+
+        public async Task PushModalAsync(Page page, bool animated = true)
+        {
+            page.OnInitialize();
+
+            BehaviorInjector.Inject(page);
+            await Navigation.PushModalAsync(page, animated);
+
+            page.OnLoaded();
+            _currentPage.OnUnloaded();
+        }
+        public async Task PushModalAsync<TParam>(Page page, TParam parameter = default(TParam), bool animated = true)
+        {
+            page.OnInitialize(parameter);
+
+            BehaviorInjector.Inject(page);
+            await Navigation.PushModalAsync(page, animated);
+
+            page.OnLoaded();
+            _currentPage.OnUnloaded();
+        }
+
+        public void RemovePage(Page page)
+        {
+            var needToCall = Navigation.NavigationStack.Last() != page;
+            Navigation.RemovePage(page);
+            
+            if(needToCall) page.OnClosed();
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/PageExtensions.cs
+++ b/MAUI/Source/Kamishibai.Maui/PageExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Kamishibai.Maui
+{
+    public static class PageExtensions
+    {
+        public static Page GetParentPage(this Page current, bool incloudCurrent = false)
+        {
+            return current.GetParentPage<Page>(incloudCurrent);
+        }
+
+        public static TPage GetParentPage<TPage>(this Page current, bool incloudCurrent = false) where TPage : Page
+        {
+            var element = incloudCurrent ? current : current?.Parent;
+            do
+            {
+                if (element is TPage result) return result;
+
+                element = element?.Parent;
+            } while (element != null);
+            return null;
+        }
+    }
+}

--- a/MAUI/Source/Kamishibai.Maui/Properties/AssemblyInfo.cs
+++ b/MAUI/Source/Kamishibai.Maui/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Kamishibai.Maui.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
This is a port of KAMISHIBAI to .NET MAUI. This should function similarly to how it works for Xamarin.Forms, although more work needs to be done to integrate into the Microsoft Dependency Injection stack that MAUI uses by default.

I've also ported all of the unit tests. They all pass.

<img width="262" alt="スクリーンショット 2022-05-13 午後6 08 48" src="https://user-images.githubusercontent.com/898335/168395658-ea4ccc5e-a61d-45e7-b714-7fe9a9ae873f.png">
