### PR TITLE
自動生成される`PresentationService` を部分クラスに変更

### DIFF
--- a/Sample/SampleBrowser/SampleBrowser.View/Page/OpenWindowPage.xaml
+++ b/Sample/SampleBrowser/SampleBrowser.View/Page/OpenWindowPage.xaml
@@ -42,6 +42,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
@@ -67,7 +68,11 @@
                 <TextBlock Grid.Row="4" Grid.Column="1"  Text="with Safe Parameter."/>
                 <TextBox Grid.Row="4" Grid.Column="2"  Text="{Binding WindowName3}" Cursor="Arrow"/>
 
-                <StackPanel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="20">
+                <Button Grid.Row="5" Grid.Column="0" Content="Open" Command="{Binding OpenSingletonCommand}" CommandParameter="{kamishibai:Window}"/>
+                <TextBlock Grid.Row="5" Grid.Column="1"  Text="App-specific Singleton." Cursor=""/>
+                <TextBox Grid.Row="5" Grid.Column="2"  Text="{Binding WindowName4}" Cursor="Arrow"/>
+
+                <StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3" Orientation="Horizontal" Margin="20">
                     <Button Content="Activate" Command="{Binding ActivateCommand}"/>
                     <Button Content="Hide" Command="{Binding HideCommand}"/>
                     <Button Content="Show" Command="{Binding ShowCommand}"/>

--- a/Sample/SampleBrowser/SampleBrowser.ViewModel/Page/OpenWindowViewModel.cs
+++ b/Sample/SampleBrowser/SampleBrowser.ViewModel/Page/OpenWindowViewModel.cs
@@ -49,6 +49,12 @@ public class OpenWindowViewModel : IDisposingAware, IPausingAware
         new(owner => _presentationService.OpenWindowWithArgumentsWindowAsync(WindowName3, owner, new OpenWindowOptions { WindowStartupLocation = SelectedWindowStartupLocation })
             .AddTo(_disposable));
 
+    public string WindowName4 { get; set; } = "Hello, Singleton (App-specific)";
+
+    public AsyncRelayCommand<object> OpenSingletonCommand =>
+        new(owner => _presentationService.OpenSingletonWindowWithArgumentsWindowAsync(WindowName4, owner, new OpenWindowOptions { WindowStartupLocation = SelectedWindowStartupLocation })
+            .AddTo(_disposable));
+
     public RelayCommand ActivateCommand => new(() => InvokeWindowAction(x => x.Activate()));
     public RelayCommand HideCommand => new(() => InvokeWindowAction(x => x.Hide()));
     public RelayCommand ShowCommand => new(() => InvokeWindowAction(x => x.Show()));

--- a/Sample/SampleBrowser/SampleBrowser.ViewModel/PresentationService.cs
+++ b/Sample/SampleBrowser/SampleBrowser.ViewModel/PresentationService.cs
@@ -1,0 +1,24 @@
+﻿using Kamishibai;
+
+namespace SampleBrowser.ViewModel;
+
+partial interface IPresentationService
+{
+    Task<IWindow> OpenSingletonWindowWithArgumentsWindowAsync(string windowName, object? owner = null, OpenWindowOptions? options = null);
+}
+
+
+partial class PresentationService
+{
+    private IWindow? singletonWindow;
+
+    public async Task<IWindow> OpenSingletonWindowWithArgumentsWindowAsync(string windowName, object? owner = null, OpenWindowOptions? options = null)
+    {
+        if (this.singletonWindow is null || this.singletonWindow.IsClosed)
+        {
+            return this.singletonWindow = await OpenWindowWithArgumentsWindowAsync(windowName, owner, options);
+        }
+        this.singletonWindow.Activate();
+        return this.singletonWindow;
+    }
+}

--- a/Source/Kamishibai.CodeAnalysis.Test/GenerateNavigateTest.cs
+++ b/Source/Kamishibai.CodeAnalysis.Test/GenerateNavigateTest.cs
@@ -30,7 +30,7 @@ namespace TestProject
         Task<bool> NavigateToFooAsync(string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -82,7 +82,7 @@ namespace TestProject
         Task<bool> NavigateToFooAsync(string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -133,7 +133,7 @@ namespace TestProject
         Task<bool> NavigateToFooAsync(string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -192,7 +192,7 @@ namespace TestProject
         Task<bool> NavigateToBarAsync(int number, Foo.Argument argument, string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -252,7 +252,7 @@ namespace TestProject
         Task<bool> NavigateToBarAsync(int number, string frameName, Foo.Argument argument);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -314,7 +314,7 @@ namespace TestProject
         Task<bool> NavigateToBarAsync(int number, Foo.Argument argument, string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -375,7 +375,7 @@ namespace TestProject
         Task<bool> NavigateToBarAsync(int? number, Foo.Argument argument, string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -432,7 +432,7 @@ namespace TestProject
         Task<bool> NavigateToBarAsync(int number, Foo.Argument argument, string frameName = """");
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 

--- a/Source/Kamishibai.CodeAnalysis.Test/GenerateOpenDialogTest.cs
+++ b/Source/Kamishibai.CodeAnalysis.Test/GenerateOpenDialogTest.cs
@@ -30,7 +30,7 @@ namespace TestProject
         Task<bool> OpenFooDialogAsync(object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -83,7 +83,7 @@ namespace TestProject
         Task<bool> OpenFooDialogAsync(object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -136,7 +136,7 @@ namespace TestProject
         Task<bool> OpenFooDialogAsync(object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -196,7 +196,7 @@ namespace TestProject
         Task<bool> OpenBarDialogAsync(int number, Foo.Argument argument, object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -258,7 +258,7 @@ namespace TestProject
         Task<bool> OpenBarDialogAsync(int number, Foo.Argument argument, object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -320,7 +320,7 @@ namespace TestProject
         Task<bool> OpenBarDialogAsync(int? number, Foo.Argument argument, object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -379,7 +379,7 @@ namespace TestProject
         Task<bool> OpenBarDialogAsync(int number, Foo.Argument argument, object? owner = null, OpenDialogOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 

--- a/Source/Kamishibai.CodeAnalysis.Test/GenerateOpenWindowTest.cs
+++ b/Source/Kamishibai.CodeAnalysis.Test/GenerateOpenWindowTest.cs
@@ -30,7 +30,7 @@ namespace TestProject
         Task<IWindow> OpenFooWindowAsync(object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -83,7 +83,7 @@ namespace TestProject
         Task<IWindow> OpenFooWindowAsync(object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -136,7 +136,7 @@ namespace TestProject
         Task<IWindow> OpenFooWindowAsync(object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -196,7 +196,7 @@ namespace TestProject
         Task<IWindow> OpenBarWindowAsync(int number, Foo.Argument argument, object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -258,7 +258,7 @@ namespace TestProject
         Task<IWindow> OpenBarWindowAsync(int number, Foo.Argument argument, object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -320,7 +320,7 @@ namespace TestProject
         Task<IWindow> OpenBarWindowAsync(int? number, Foo.Argument argument, object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 
@@ -379,7 +379,7 @@ namespace TestProject
         Task<IWindow> OpenBarWindowAsync(int? number, Foo.Argument argument, object? owner = null, OpenWindowOptions? options = null);
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 

--- a/Source/Kamishibai.CodeAnalysis/Generator/PresentationServiceTemplate.cs
+++ b/Source/Kamishibai.CodeAnalysis/Generator/PresentationServiceTemplate.cs
@@ -66,7 +66,7 @@ foreach(var openDialogInfo in OpenDialogInfos)
 
             this.Write(@"    }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 

--- a/Source/Kamishibai.CodeAnalysis/Generator/PresentationServiceTemplate.tt
+++ b/Source/Kamishibai.CodeAnalysis/Generator/PresentationServiceTemplate.tt
@@ -39,7 +39,7 @@ foreach(var openDialogInfo in OpenDialogInfos)
 #>
     }
 
-    public class PresentationService : PresentationServiceBase, IPresentationService
+    public partial class PresentationService : PresentationServiceBase, IPresentationService
     {
         private readonly IServiceProvider _serviceProvider;
 


### PR DESCRIPTION
Fix #28 

## 変更点

### コード生成
* テンプレートの`PresentationService` の定義に`partial`追加

### サンプルコード
* アプリ固有の実装としてシングルトンウィンドウを開くサンプル追加

### テストコード
* 生成後のコードに`partial`追記
